### PR TITLE
Dev

### DIFF
--- a/packages/incremental-merkle-tree.sol/contracts/IncrementalBinaryTree.sol
+++ b/packages/incremental-merkle-tree.sol/contracts/IncrementalBinaryTree.sol
@@ -102,7 +102,7 @@ library IncrementalBinaryTree {
 
         uint256 updateIndex;
         for (uint8 i = 0; i < depth; ) {
-            updateIndex |= uint(proofPathIndices[i] & 1) << uint(i);
+            updateIndex |= uint256(proofPathIndices[i] & 1) << uint256(i);
             if (proofPathIndices[i] == 0) {
                 if (proofSiblings[i] == self.lastSubtrees[i][1]) {
                     self.lastSubtrees[i][0] = hash;

--- a/packages/incremental-merkle-tree.sol/contracts/IncrementalBinaryTree.sol
+++ b/packages/incremental-merkle-tree.sol/contracts/IncrementalBinaryTree.sol
@@ -102,7 +102,7 @@ library IncrementalBinaryTree {
 
         uint256 updateIndex;
         for (uint8 i = 0; i < depth; ) {
-            updateIndex |= uint(proofPathIndices[i]) << uint(i);
+            updateIndex |= uint(proofPathIndices[i] & 1) << uint(i);
             if (proofPathIndices[i] == 0) {
                 if (proofSiblings[i] == self.lastSubtrees[i][1]) {
                     self.lastSubtrees[i][0] = hash;

--- a/packages/incremental-merkle-tree.sol/contracts/IncrementalBinaryTree.sol
+++ b/packages/incremental-merkle-tree.sol/contracts/IncrementalBinaryTree.sol
@@ -100,7 +100,9 @@ library IncrementalBinaryTree {
         uint256 depth = self.depth;
         uint256 hash = newLeaf;
 
+        uint256 updateIndex;
         for (uint8 i = 0; i < depth; ) {
+            updateIndex |= uint(proofPathIndices[i]) << uint(i);
             if (proofPathIndices[i] == 0) {
                 if (proofSiblings[i] == self.lastSubtrees[i][1]) {
                     self.lastSubtrees[i][0] = hash;
@@ -119,6 +121,7 @@ library IncrementalBinaryTree {
                 ++i;
             }
         }
+        require(updateIndex < self.numberOfLeaves, "IncrementalBinaryTree: leaf index out of range");
 
         self.root = hash;
     }

--- a/packages/incremental-merkle-tree.sol/contracts/IncrementalQuinTree.sol
+++ b/packages/incremental-merkle-tree.sol/contracts/IncrementalQuinTree.sol
@@ -119,7 +119,7 @@ library IncrementalQuinTree {
         uint256 updateIndex;
         for (uint8 i = 0; i < depth; ) {
             uint256[5] memory nodes;
-            updateIndex += proofPathIndices[i] * 5 ** i;
+            updateIndex += proofPathIndices[i] * 5**i;
             for (uint8 j = 0; j < 5; ) {
                 if (j < proofPathIndices[i]) {
                     nodes[j] = proofSiblings[i][j];

--- a/packages/incremental-merkle-tree.sol/contracts/IncrementalQuinTree.sol
+++ b/packages/incremental-merkle-tree.sol/contracts/IncrementalQuinTree.sol
@@ -116,9 +116,10 @@ library IncrementalQuinTree {
         uint256 depth = self.depth;
         uint256 hash = newLeaf;
 
+        uint256 updateIndex;
         for (uint8 i = 0; i < depth; ) {
             uint256[5] memory nodes;
-
+            updateIndex += proofPathIndices[i] * 5 ** i;
             for (uint8 j = 0; j < 5; ) {
                 if (j < proofPathIndices[i]) {
                     nodes[j] = proofSiblings[i][j];
@@ -142,6 +143,7 @@ library IncrementalQuinTree {
                 ++i;
             }
         }
+        require(updateIndex < self.numberOfLeaves, "IncrementalQuinTree: leaf index out of range");
 
         self.root = hash;
     }

--- a/packages/incremental-merkle-tree.sol/test/IncrementalQuinTreeTest.ts
+++ b/packages/incremental-merkle-tree.sol/test/IncrementalQuinTreeTest.ts
@@ -217,13 +217,7 @@ describe("IncrementalQuinTreeTest", () => {
         // now we can make a merkle proof of zero being included at the uninitialized index
         const { pathIndices, siblings } = tree.createProof(6)
 
-        const transaction = contract.updateLeaf(
-            treeId,
-            BigInt(0),
-            leaf,
-            siblings,
-            pathIndices
-        )
+        const transaction = contract.updateLeaf(treeId, BigInt(0), leaf, siblings, pathIndices)
         await expect(transaction).to.be.revertedWith("IncrementalQuinTree: leaf index out of range")
     })
 

--- a/packages/incremental-merkle-tree.sol/test/IncrementalQuinTreeTest.ts
+++ b/packages/incremental-merkle-tree.sol/test/IncrementalQuinTreeTest.ts
@@ -185,6 +185,48 @@ describe("IncrementalQuinTreeTest", () => {
         await expect(transaction).to.emit(contract, "LeafRemoved").withArgs(treeId, BigInt(2), root)
     })
 
+    it("Should not update a leaf that hasn't been inserted yet", async () => {
+        // deploy a new, empty tree
+        const treeId = ethers.utils.formatBytes32String("brokenTree")
+        contract.createTree(treeId, depth)
+        const tree = createTree(depth, 0, 5)
+
+        // insert 4 leaves into the tree
+        for (let i = 0; i < 4; i += 1) {
+            tree.insert(BigInt(i + 1))
+            await contract.insertLeaf(treeId, BigInt(i + 1))
+        }
+
+        // we're going to try to update leaf 7, despite there only being 4 leaves in the tree
+        const leaf = BigInt(42069)
+
+        // note that we can insert zeros into the js library tree and the root won't change!
+        // that's because we use the zeros optimization to calculate the roots efficiently.
+        // technically speaking, there isn't an "empty" tree, there is only a tree that is
+        // entirely full of the zero value at every index. therefore inserting the zero value
+        // at any point into an incremental merkle tree doesn't change it's root, because
+        // that is already the data the root was calculated from previously. in principle,
+        // we can update any leaf that hasn't been inserted yet using this method
+        const rootBeforeZeros = tree.root
+        tree.insert(0)
+        tree.insert(0)
+        tree.insert(0)
+        // the root doesn't change because the tree started full with 0s!
+        expect(tree.root).to.be.equal(rootBeforeZeros)
+
+        // now we can make a merkle proof of zero being included at the uninitialized index
+        const { pathIndices, siblings } = tree.createProof(6)
+
+        const transaction = contract.updateLeaf(
+            treeId,
+            BigInt(0),
+            leaf,
+            siblings,
+            pathIndices
+        )
+        await expect(transaction).to.be.revertedWith("IncrementalQuinTree: leaf index out of range")
+    })
+
     it("Should not remove a leaf that does not exist", async () => {
         const treeId = ethers.utils.formatBytes32String("hello")
         const tree = createTree(depth, 3, 5)


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description
Change the IncrementalBinaryTree.sol `update` method to require the index of the leaf being updated to be already inserted into the tree.

We do this by recovering the `updateIndex` from the `proofPathIndices` array, then comparing with `self.numberOfLeaves` in the tree. Because `self.numberOfLeaves` is the length of the leaves in the tree, which is one greater than the index of the last leaf in the tree, the requirement that `updateIndex < self.numberOfLeaves` covers all the existing leaves in the tree.

I also added a unit test to check that this operation reverts when an uninitialized leaf is updated. [IncrementalBinaryTreeTest.ts#L188](https://github.com/twister-dev/zk-kit/blob/dev/packages/incremental-merkle-tree.sol/test/IncrementalBinaryTreeTest.ts#L188)


<!--- Describe your changes in detail -->

## Related Issue

This is a bug fix as described in [zk-kit/issues/32](https://github.com/privacy-scaling-explorations/zk-kit/issues/32).


## Does this introduce a breaking change?

-   [ ] Yes
-   [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The IncrementalQuinTree requires a bug fix, too. I am looking into fixing it as well.
