### PR TITLE
New checks for path indices

### DIFF
--- a/packages/incremental-merkle-tree.sol/contracts/IncrementalBinaryTree.sol
+++ b/packages/incremental-merkle-tree.sol/contracts/IncrementalBinaryTree.sol
@@ -104,7 +104,7 @@ library IncrementalBinaryTree {
         uint256 updateIndex;
 
         for (uint8 i = 0; i < depth; ) {
-            updateIndex |= uint256(proofPathIndices[i] & 1) << uint256(i);
+            updateIndex |= uint256(proofPathIndices[i]) << uint256(i);
 
             if (proofPathIndices[i] == 0) {
                 if (proofSiblings[i] == self.lastSubtrees[i][1]) {

--- a/packages/incremental-merkle-tree.sol/contracts/IncrementalBinaryTree.sol
+++ b/packages/incremental-merkle-tree.sol/contracts/IncrementalBinaryTree.sol
@@ -101,10 +101,11 @@ library IncrementalBinaryTree {
 
         uint256 depth = self.depth;
         uint256 hash = newLeaf;
-
         uint256 updateIndex;
+
         for (uint8 i = 0; i < depth; ) {
             updateIndex |= uint256(proofPathIndices[i] & 1) << uint256(i);
+
             if (proofPathIndices[i] == 0) {
                 if (proofSiblings[i] == self.lastSubtrees[i][1]) {
                     self.lastSubtrees[i][0] = hash;
@@ -167,6 +168,11 @@ library IncrementalBinaryTree {
             require(
                 proofSiblings[i] < SNARK_SCALAR_FIELD,
                 "IncrementalBinaryTree: sibling node must be < SNARK_SCALAR_FIELD"
+            );
+
+            require(
+                proofPathIndices[i] == 1 || proofPathIndices[i] == 0,
+                "IncrementalBinaryTree: path index is neither 0 nor 1"
             );
 
             if (proofPathIndices[i] == 0) {

--- a/packages/incremental-merkle-tree.sol/contracts/IncrementalQuinTree.sol
+++ b/packages/incremental-merkle-tree.sol/contracts/IncrementalQuinTree.sol
@@ -117,11 +117,12 @@ library IncrementalQuinTree {
 
         uint256 depth = self.depth;
         uint256 hash = newLeaf;
-
         uint256 updateIndex;
+
         for (uint8 i = 0; i < depth; ) {
             uint256[5] memory nodes;
             updateIndex += proofPathIndices[i] * 5**i;
+
             for (uint8 j = 0; j < 5; ) {
                 if (j < proofPathIndices[i]) {
                     nodes[j] = proofSiblings[i][j];
@@ -187,6 +188,11 @@ library IncrementalQuinTree {
 
         for (uint8 i = 0; i < depth; ) {
             uint256[5] memory nodes;
+
+            require(
+                proofPathIndices[i] >= 0 && proofPathIndices[i] < 5,
+                "IncrementalQuinTree: path index is not between 0 and 4"
+            );
 
             for (uint8 j = 0; j < 5; ) {
                 if (j < proofPathIndices[i]) {

--- a/packages/incremental-merkle-tree.sol/test/IncrementalBinaryTreeTest.ts
+++ b/packages/incremental-merkle-tree.sol/test/IncrementalBinaryTreeTest.ts
@@ -117,6 +117,33 @@ describe("IncrementalBinaryTreeTest", () => {
         await expect(transaction).to.be.revertedWith("IncrementalBinaryTree: leaf must be < SNARK_SCALAR_FIELD")
     })
 
+    it("Should not update a leaf if the path indices are wrong", async () => {
+        const treeId = ethers.utils.formatBytes32String("tree2")
+        const tree = createTree(depth, 0)
+
+        for (let i = 0; i < 4; i += 1) {
+            tree.insert(BigInt(i + 1))
+        }
+
+        const leaf = BigInt(1337)
+
+        tree.update(2, leaf)
+
+        const { pathIndices, siblings } = tree.createProof(2)
+
+        pathIndices[0] = 2
+
+        const transaction = contract.updateLeaf(
+            treeId,
+            BigInt(4),
+            leaf,
+            siblings.map((s) => s[0]),
+            pathIndices
+        )
+
+        await expect(transaction).to.be.revertedWith("IncrementalBinaryTree: path index is neither 0 nor 1")
+    })
+
     it("Should not update a leaf if the wrong current leaf is given", async () => {
         const treeId = ethers.utils.formatBytes32String("tree2")
         const tree = createTree(depth, 0)

--- a/packages/incremental-merkle-tree.sol/test/IncrementalQuinTreeTest.ts
+++ b/packages/incremental-merkle-tree.sol/test/IncrementalQuinTreeTest.ts
@@ -118,6 +118,27 @@ describe("IncrementalQuinTreeTest", () => {
         await expect(transaction).to.be.revertedWith("IncrementalQuinTree: leaf must be < SNARK_SCALAR_FIELD")
     })
 
+    it("Should not update a leaf if the path indices are wrong", async () => {
+        const treeId = ethers.utils.formatBytes32String("tree2")
+        const tree = createTree(depth, 0, 5)
+
+        for (let i = 0; i < 6; i += 1) {
+            tree.insert(BigInt(i + 1))
+        }
+
+        const leaf = BigInt(1337)
+
+        tree.update(2, leaf)
+
+        const { pathIndices, siblings } = tree.createProof(2)
+
+        pathIndices[3] = 6
+
+        const transaction = contract.updateLeaf(treeId, BigInt(3), leaf, siblings, pathIndices)
+
+        await expect(transaction).to.be.revertedWith("IncrementalQuinTree: path index is not between 0 and 4")
+    })
+
     it("Should not update a leaf if the wrong current leaf is given", async () => {
         const treeId = ethers.utils.formatBytes32String("tree2")
         const tree = createTree(depth, 0, 5)


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR adds a `require` to check if the path indices of a proof of membership are the right numbers.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #37 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This bug was found by [Veridise](https://veridise.com/) during their audit of Semaphore.
