### PR TITLE
chore: bump poseidon-solidity

### DIFF
--- a/packages/hashtower.sol/contracts/package.json
+++ b/packages/hashtower.sol/contracts/package.json
@@ -30,6 +30,6 @@
         "access": "public"
     },
     "dependencies": {
-        "poseidon-solidity": "0.0.3"
+        "poseidon-solidity": "0.0.4"
     }
 }

--- a/packages/hashtower.sol/package.json
+++ b/packages/hashtower.sol/package.json
@@ -34,7 +34,7 @@
         "typechain": "^8.1.0"
     },
     "dependencies": {
-        "poseidon-solidity": "0.0.3"
+        "poseidon-solidity": "0.0.4"
     },
     "config": {
         "solidity": {

--- a/packages/incremental-merkle-tree.sol/contracts/package.json
+++ b/packages/incremental-merkle-tree.sol/contracts/package.json
@@ -29,6 +29,6 @@
         "access": "public"
     },
     "dependencies": {
-        "poseidon-solidity": "0.0.3"
+        "poseidon-solidity": "0.0.4"
     }
 }

--- a/packages/incremental-merkle-tree.sol/package.json
+++ b/packages/incremental-merkle-tree.sol/package.json
@@ -35,7 +35,7 @@
         "typechain": "^8.1.0"
     },
     "dependencies": {
-        "poseidon-solidity": "0.0.3"
+        "poseidon-solidity": "0.0.4"
     },
     "config": {
         "solidity": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10307,7 +10307,7 @@ __metadata:
     ethers: ^5.4.7
     hardhat: ^2.13.0
     hardhat-gas-reporter: ^1.0.8
-    poseidon-solidity: 0.0.3
+    poseidon-solidity: 0.0.4
     prettier-plugin-solidity: ^1.0.0-beta.19
     solhint: ^3.3.6
     solhint-plugin-prettier: ^0.0.5
@@ -10726,7 +10726,7 @@ __metadata:
     ethers: ^5.4.7
     hardhat: ^2.13.0
     hardhat-gas-reporter: ^1.0.8
-    poseidon-solidity: 0.0.3
+    poseidon-solidity: 0.0.4
     prettier-plugin-solidity: ^1.0.0-beta.19
     solhint: ^3.3.6
     solhint-plugin-prettier: ^0.0.5
@@ -15118,10 +15118,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"poseidon-solidity@npm:0.0.3":
-  version: 0.0.3
-  resolution: "poseidon-solidity@npm:0.0.3"
-  checksum: 489e392a382c015be361724fb772386fd856ec84897907621e0b46fe436ecb8ce935e1153071ca156fde25e961b5d15c795459ac40b141a074b41f92e4f07480
+"poseidon-solidity@npm:0.0.4":
+  version: 0.0.4
+  resolution: "poseidon-solidity@npm:0.0.4"
+  checksum: c4c3c7099a8f77a5d2c6c22ad819ac920b39b7c43c0355e8fa7a6586671416e16903e997250eed08647a22876349cdf34bc4ecb82c664d8d40f52c11fd30bb53
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

The new poseidon-solidity is ~9% cheaper for `PoseidonT2`/`PoseidonT3`

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
