### PR TITLE
New parameter to init tree with a list of leaves

### DIFF
--- a/packages/incremental-merkle-tree/README.md
+++ b/packages/incremental-merkle-tree/README.md
@@ -75,13 +75,17 @@ or [JSDelivr](https://www.jsdelivr.com/):
 
 ## 📜 Usage
 
-\# **new IncrementalMerkleTree**(hash: _HashFunction_, depth: _number_, zero: _Node_, arity: _number_): _IncrementalMerkleTree_
+\# **new IncrementalMerkleTree**(hash: _HashFunction_, depth: _number_, zero: _Node_, arity: _number_, leaves: _Node\[]_): _IncrementalMerkleTree_
 
 ```typescript
 import { IncrementalMerkleTree } from "@zk-kit/incremental-merkle-tree"
 import { poseidon } from "circomlibjs" // v0.0.8
 
 const tree = new IncrementalMerkleTree(poseidon, 16, BigInt(0), 2) // Binary tree.
+
+// Or, if you already have tree leaves to insert:
+const leaves = [1, 2, 3]
+const tree = new IncrementalMerkleTree(poseidon, 16, BigInt(0), 2, leaves)
 ```
 
 \# **insert**(leaf: _Node_)

--- a/packages/incremental-merkle-tree/src/incremental-merkle-tree.ts
+++ b/packages/incremental-merkle-tree/src/incremental-merkle-tree.ts
@@ -71,8 +71,8 @@ export default class IncrementalMerkleTree {
                     const position = index * arity
                     const children = []
 
-                    for (let i = position; i < position + arity; i += 1) {
-                        children.push(this._nodes[level][i] || this.zeroes[level])
+                    for (let i = 0; i < arity; i += 1) {
+                        children.push(this._nodes[level][position + i] ?? this.zeroes[level])
                     }
 
                     this._nodes[level + 1][index] = hash(children)

--- a/packages/incremental-merkle-tree/tests/index.test.ts
+++ b/packages/incremental-merkle-tree/tests/index.test.ts
@@ -19,9 +19,11 @@ describe("Incremental Merkle Tree", () => {
             it("Should not initialize a tree with wrong parameters", () => {
                 const fun1 = () => new IncrementalMerkleTree(undefined as any, 33, 0, arity)
                 const fun2 = () => new IncrementalMerkleTree(1 as any, 33, 0, arity)
+                const fun3 = () => new IncrementalMerkleTree(poseidon, depth, BigInt(0), arity, 2 as any)
 
                 expect(fun1).toThrow("Parameter 'hash' is not defined")
                 expect(fun2).toThrow("Parameter 'hash' is none of these types: function")
+                expect(fun3).toThrow("Parameter 'leaves' is none of these types: object")
             })
 
             it("Should not initialize a tree with depth > 32", () => {
@@ -30,11 +32,37 @@ describe("Incremental Merkle Tree", () => {
                 expect(fun).toThrow("The tree depth must be between 1 and 32")
             })
 
+            it("Should not initialize a tree with a number of leaves > arity ** depth", () => {
+                const leaves = Array.from(Array(100).keys())
+
+                const fun = () => new IncrementalMerkleTree(poseidon, 2, BigInt(0), arity, leaves)
+
+                expect(fun).toThrow(`The tree cannot contain more than ${arity ** 2} leaves`)
+            })
+
             it("Should initialize a tree", () => {
                 expect(tree.depth).toEqual(depth)
                 expect(tree.leaves).toHaveLength(0)
                 expect(tree.zeroes).toHaveLength(depth)
                 expect(tree.arity).toEqual(arity)
+            })
+
+            it("Should initialize a tree with 100 leaves", () => {
+                const leaves = Array.from(Array(100).keys())
+
+                const tree = new IncrementalMerkleTree(poseidon, depth, BigInt(0), arity, leaves)
+
+                const tree2 = new IncrementalMerkleTree(poseidon, depth, BigInt(0), arity)
+
+                for (const leaf of leaves) {
+                    tree2.insert(leaf)
+                }
+
+                expect(tree.depth).toEqual(depth)
+                expect(tree.leaves).toHaveLength(100)
+                expect(tree.zeroes).toHaveLength(depth)
+                expect(tree.arity).toEqual(arity)
+                expect(tree.root).toEqual(tree2.root)
             })
 
             it("Should not insert a leaf in a full tree", () => {

--- a/packages/incremental-merkle-tree/tests/index.test.ts
+++ b/packages/incremental-merkle-tree/tests/index.test.ts
@@ -47,23 +47,25 @@ describe("Incremental Merkle Tree", () => {
                 expect(tree.arity).toEqual(arity)
             })
 
-            it("Should initialize a tree with 100 leaves", () => {
-                const leaves = Array.from(Array(100).keys())
+            for (let numberOfLeaves = 100; numberOfLeaves < 116; numberOfLeaves += 1) {
+                it(`Should initialize a tree with ${numberOfLeaves} leaves`, () => {
+                    const leaves = Array.from(Array(numberOfLeaves).keys())
 
-                const tree = new IncrementalMerkleTree(poseidon, depth, BigInt(0), arity, leaves)
+                    const tree = new IncrementalMerkleTree(poseidon, depth, BigInt(0), arity, leaves)
 
-                const tree2 = new IncrementalMerkleTree(poseidon, depth, BigInt(0), arity)
+                    const tree2 = new IncrementalMerkleTree(poseidon, depth, BigInt(0), arity)
 
-                for (const leaf of leaves) {
-                    tree2.insert(leaf)
-                }
+                    for (const leaf of leaves) {
+                        tree2.insert(leaf)
+                    }
 
-                expect(tree.depth).toEqual(depth)
-                expect(tree.leaves).toHaveLength(100)
-                expect(tree.zeroes).toHaveLength(depth)
-                expect(tree.arity).toEqual(arity)
-                expect(tree.root).toEqual(tree2.root)
-            })
+                    expect(tree.depth).toEqual(depth)
+                    expect(tree.leaves).toHaveLength(numberOfLeaves)
+                    expect(tree.zeroes).toHaveLength(depth)
+                    expect(tree.arity).toEqual(arity)
+                    expect(tree.root).toEqual(tree2.root)
+                })
+            }
 
             it("Should not insert a leaf in a full tree", () => {
                 const fullTree = new IncrementalMerkleTree(poseidon, 1, BigInt(0), 3)


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR adds a new parameter to the `IncrementalMerkleTree` JS class to allow devs to efficiently add a list of leaves without the need to add them manually with the `insert` function and then avoiding calculating the same hashes/non-leaf nodes a number of times equal to the tree arity.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
