### PR TITLE
fix(incremental-merkle-tree-sol): deterministically deploy poseidon hash contracts

### DIFF
--- a/packages/incremental-merkle-tree.sol/tasks/deploy-ibt-test.ts
+++ b/packages/incremental-merkle-tree.sol/tasks/deploy-ibt-test.ts
@@ -1,11 +1,25 @@
 import { Contract } from "ethers"
 import { task, types } from "hardhat/config"
+import { proxy, PoseidonT3 } from "poseidon-solidity"
 
 task("deploy:ibt-test", "Deploy an IncrementalBinaryTreeTest contract")
     .addOptionalParam<boolean>("logs", "Print the logs", true, types.boolean)
     .setAction(async ({ logs }, { ethers }): Promise<Contract> => {
-        const PoseidonT3Factory = await ethers.getContractFactory("PoseidonT3")
-        const PoseidonT3 = await PoseidonT3Factory.deploy()
+        // deterministically deploy PoseidonT3
+        const signer = await ethers.getSigner()
+        if ((await ethers.provider.getCode(proxy.address)) === "0x") {
+            await signer.sendTransaction({
+                to: proxy.from,
+                value: proxy.gas
+            })
+            await ethers.provider.sendTransaction(proxy.tx)
+        }
+        if ((await ethers.provider.getCode(PoseidonT3.address)) === "0x") {
+            await signer.sendTransaction({
+                to: proxy.address,
+                data: PoseidonT3.data
+            })
+        }
 
         if (logs) {
             console.info(`PoseidonT3 library has been deployed to: ${PoseidonT3.address}`)

--- a/packages/incremental-merkle-tree.sol/tasks/deploy-incremental-binary-tree.ts
+++ b/packages/incremental-merkle-tree.sol/tasks/deploy-incremental-binary-tree.ts
@@ -1,11 +1,25 @@
 import { Contract } from "ethers"
 import { task, types } from "hardhat/config"
+import { proxy, PoseidonT3 } from "poseidon-solidity"
 
 task("deploy:incremental-binary-tree-test", "Deploy an IncrementalBinaryTreeTest contract")
     .addOptionalParam<boolean>("logs", "Print the logs", true, types.boolean)
     .setAction(async ({ logs }, { ethers }): Promise<Contract> => {
-        const PoseidonT3Factory = await ethers.getContractFactory("PoseidonT3")
-        const PoseidonT3 = await PoseidonT3Factory.deploy()
+        // deterministically deploy PoseidonT3
+        const signer = await ethers.getSigner()
+        if ((await ethers.provider.getCode(proxy.address)) === "0x") {
+            await signer.sendTransaction({
+                to: proxy.from,
+                value: proxy.gas
+            })
+            await ethers.provider.sendTransaction(proxy.tx)
+        }
+        if ((await ethers.provider.getCode(PoseidonT3.address)) === "0x") {
+            await signer.sendTransaction({
+                to: proxy.address,
+                data: PoseidonT3.data
+            })
+        }
 
         if (logs) {
             console.info(`PoseidonT3 library has been deployed to: ${PoseidonT3.address}`)


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

Uses the deterministic deployment info in the `poseidon-solidity` package. This will cause the hash contract to be re-used if it exists onchain.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
