### PR TITLE
feat(incremental-merkle-tree.sol): lazy merkle tree implementation

### DIFF
--- a/packages/incremental-merkle-tree.sol/contracts/LazyMerkleTree.sol
+++ b/packages/incremental-merkle-tree.sol/contracts/LazyMerkleTree.sol
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "poseidon-solidity/PoseidonT3.sol";
+
+struct LazyTreeData {
+    uint32 maxIndex;
+    uint40 numberOfLeaves;
+    mapping(uint256 => uint256) elements;
+}
+
+library LazyMerkleTree {
+    uint256 public constant SNARK_SCALAR_FIELD =
+        21888242871839275222246405745257275088548364400416034343698204186575808495617;
+    uint8 public constant MAX_DEPTH = 32;
+    uint40 public constant MAX_INDEX = (1 << 32) - 1;
+
+    function init(LazyTreeData storage self, uint8 depth) public {
+        require(depth <= MAX_DEPTH, "LazyMerkleTree: Tree too large");
+        self.maxIndex = uint32((1 << depth) - 1);
+        self.numberOfLeaves = 0;
+    }
+
+    function reset(LazyTreeData storage self) public {
+        self.numberOfLeaves = 0;
+    }
+
+    function indexForElement(uint8 level, uint40 index) public pure returns (uint40) {
+        // store the elements sparsely
+        return MAX_INDEX * level + index;
+    }
+
+    function insert(LazyTreeData storage self, uint256 leaf) public {
+        uint40 index = self.numberOfLeaves;
+        self.numberOfLeaves = index + 1;
+        require(leaf < SNARK_SCALAR_FIELD, "LazyMerkleTree: leaf must be < SNARK_SCALAR_FIELD");
+        require(index < self.maxIndex, "LazyMerkleTree: tree is full");
+
+        uint256 hash = leaf;
+
+        for (uint8 i = 0; true; ) {
+            self.elements[indexForElement(i, index)] = hash;
+            // it's a left element so we don't hash until there's a right element
+            if (index & 1 == 0) break;
+            uint40 elementIndex = indexForElement(i, index - 1);
+            hash = PoseidonT3.hash([self.elements[elementIndex], hash]);
+            unchecked {
+                index >>= 1;
+                i++;
+            }
+        }
+    }
+
+    function update(
+        LazyTreeData storage self,
+        uint256 leaf,
+        uint40 index
+    ) public {
+        require(leaf < SNARK_SCALAR_FIELD, "LazyMerkleTree: leaf must be < SNARK_SCALAR_FIELD");
+        uint40 numberOfLeaves = self.numberOfLeaves;
+        require(index < numberOfLeaves, "LazyMerkleTree: leaf must exist");
+
+        uint256 hash = leaf;
+
+        for (uint8 i = 0; true; ) {
+            self.elements[indexForElement(i, index)] = hash;
+            uint256 levelCount = numberOfLeaves >> (i + 1);
+            if (levelCount <= index >> 1) break;
+            if (index & 1 == 0) {
+                uint40 elementIndex = indexForElement(i, index + 1);
+                hash = PoseidonT3.hash([hash, self.elements[elementIndex]]);
+            } else {
+                uint40 elementIndex = indexForElement(i, index - 1);
+                hash = PoseidonT3.hash([self.elements[elementIndex], hash]);
+            }
+            unchecked {
+                index >>= 1;
+                i++;
+            }
+        }
+    }
+
+    function root(LazyTreeData storage self) public view returns (uint256) {
+        // this will always short circuit if self.numberOfLeaves == 0
+        uint40 numberOfLeaves = self.numberOfLeaves;
+        if (numberOfLeaves == 0) return defaultZero(1);
+        uint40 index = numberOfLeaves - 1;
+
+        uint256[MAX_DEPTH + 1] memory levels;
+
+        if (index & 1 == 0) {
+            levels[0] = self.elements[indexForElement(0, index)];
+        } else {
+            levels[0] = defaultZero(0);
+        }
+        // dynamically determine a depth
+        uint8 depth = 1;
+        while (uint8(2)**depth < numberOfLeaves) {
+            depth++;
+        }
+        for (uint8 i = 0; i < depth; ) {
+            if (index & 1 == 0) {
+                levels[i + 1] = PoseidonT3.hash([levels[i], defaultZero(i)]);
+            } else {
+                uint256 levelCount = (numberOfLeaves) >> (i + 1);
+                if (levelCount > index >> 1) {
+                    uint256 parent = self.elements[indexForElement(i + 1, index >> 1)];
+                    levels[i + 1] = parent;
+                } else {
+                    uint256 sibling = self.elements[indexForElement(i, index - 1)];
+                    levels[i + 1] = PoseidonT3.hash([sibling, levels[i]]);
+                }
+            }
+            unchecked {
+                index >>= 1;
+                i++;
+            }
+        }
+        return levels[depth];
+    }
+
+    uint256 public constant Z_0 = 0;
+    uint256 public constant Z_1 = 14744269619966411208579211824598458697587494354926760081771325075741142829156;
+    uint256 public constant Z_2 = 7423237065226347324353380772367382631490014989348495481811164164159255474657;
+    uint256 public constant Z_3 = 11286972368698509976183087595462810875513684078608517520839298933882497716792;
+    uint256 public constant Z_4 = 3607627140608796879659380071776844901612302623152076817094415224584923813162;
+    uint256 public constant Z_5 = 19712377064642672829441595136074946683621277828620209496774504837737984048981;
+    uint256 public constant Z_6 = 20775607673010627194014556968476266066927294572720319469184847051418138353016;
+    uint256 public constant Z_7 = 3396914609616007258851405644437304192397291162432396347162513310381425243293;
+    uint256 public constant Z_8 = 21551820661461729022865262380882070649935529853313286572328683688269863701601;
+    uint256 public constant Z_9 = 6573136701248752079028194407151022595060682063033565181951145966236778420039;
+    uint256 public constant Z_10 = 12413880268183407374852357075976609371175688755676981206018884971008854919922;
+    uint256 public constant Z_11 = 14271763308400718165336499097156975241954733520325982997864342600795471836726;
+    uint256 public constant Z_12 = 20066985985293572387227381049700832219069292839614107140851619262827735677018;
+    uint256 public constant Z_13 = 9394776414966240069580838672673694685292165040808226440647796406499139370960;
+    uint256 public constant Z_14 = 11331146992410411304059858900317123658895005918277453009197229807340014528524;
+    uint256 public constant Z_15 = 15819538789928229930262697811477882737253464456578333862691129291651619515538;
+    uint256 public constant Z_16 = 19217088683336594659449020493828377907203207941212636669271704950158751593251;
+    uint256 public constant Z_17 = 21035245323335827719745544373081896983162834604456827698288649288827293579666;
+    uint256 public constant Z_18 = 6939770416153240137322503476966641397417391950902474480970945462551409848591;
+    uint256 public constant Z_19 = 10941962436777715901943463195175331263348098796018438960955633645115732864202;
+    uint256 public constant Z_20 = 15019797232609675441998260052101280400536945603062888308240081994073687793470;
+    uint256 public constant Z_21 = 11702828337982203149177882813338547876343922920234831094975924378932809409969;
+    uint256 public constant Z_22 = 11217067736778784455593535811108456786943573747466706329920902520905755780395;
+    uint256 public constant Z_23 = 16072238744996205792852194127671441602062027943016727953216607508365787157389;
+    uint256 public constant Z_24 = 17681057402012993898104192736393849603097507831571622013521167331642182653248;
+    uint256 public constant Z_25 = 21694045479371014653083846597424257852691458318143380497809004364947786214945;
+    uint256 public constant Z_26 = 8163447297445169709687354538480474434591144168767135863541048304198280615192;
+    uint256 public constant Z_27 = 14081762237856300239452543304351251708585712948734528663957353575674639038357;
+    uint256 public constant Z_28 = 16619959921569409661790279042024627172199214148318086837362003702249041851090;
+    uint256 public constant Z_29 = 7022159125197495734384997711896547675021391130223237843255817587255104160365;
+    uint256 public constant Z_30 = 4114686047564160449611603615418567457008101555090703535405891656262658644463;
+    uint256 public constant Z_31 = 12549363297364877722388257367377629555213421373705596078299904496781819142130;
+    uint256 public constant Z_32 = 21443572485391568159800782191812935835534334817699172242223315142338162256601;
+
+    function defaultZero(uint8 index) public pure returns (uint256) {
+        if (index == 0) return Z_0;
+        if (index == 1) return Z_1;
+        if (index == 2) return Z_2;
+        if (index == 3) return Z_3;
+        if (index == 4) return Z_4;
+        if (index == 5) return Z_5;
+        if (index == 6) return Z_6;
+        if (index == 7) return Z_7;
+        if (index == 8) return Z_8;
+        if (index == 9) return Z_9;
+        if (index == 10) return Z_10;
+        if (index == 11) return Z_11;
+        if (index == 12) return Z_12;
+        if (index == 13) return Z_13;
+        if (index == 14) return Z_14;
+        if (index == 15) return Z_15;
+        if (index == 16) return Z_16;
+        if (index == 17) return Z_17;
+        if (index == 18) return Z_18;
+        if (index == 19) return Z_19;
+        if (index == 20) return Z_20;
+        if (index == 21) return Z_21;
+        if (index == 22) return Z_22;
+        if (index == 23) return Z_23;
+        if (index == 24) return Z_24;
+        if (index == 25) return Z_25;
+        if (index == 26) return Z_26;
+        if (index == 27) return Z_27;
+        if (index == 28) return Z_28;
+        if (index == 29) return Z_29;
+        if (index == 30) return Z_30;
+        if (index == 31) return Z_31;
+        if (index == 32) return Z_32;
+        revert("LazyMerkleTree: defaultZero bad index");
+    }
+}

--- a/packages/incremental-merkle-tree.sol/contracts/LazyMerkleTree.sol
+++ b/packages/incremental-merkle-tree.sol/contracts/LazyMerkleTree.sol
@@ -32,13 +32,14 @@ library LazyMerkleTree {
 
     function insert(LazyTreeData storage self, uint256 leaf) public {
         uint40 index = self.numberOfLeaves;
-        self.numberOfLeaves = index + 1;
         require(leaf < SNARK_SCALAR_FIELD, "LazyMerkleTree: leaf must be < SNARK_SCALAR_FIELD");
         require(index < self.maxIndex, "LazyMerkleTree: tree is full");
 
+        self.numberOfLeaves = index + 1;
+
         uint256 hash = leaf;
 
-        for (uint8 i = 0; true; ) {
+        for (uint8 i = 0; ; ) {
             self.elements[indexForElement(i, index)] = hash;
             // it's a left element so we don't hash until there's a right element
             if (index & 1 == 0) break;

--- a/packages/incremental-merkle-tree.sol/contracts/test/LazyMerkleTreeTest.sol
+++ b/packages/incremental-merkle-tree.sol/contracts/test/LazyMerkleTreeTest.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.4;
+
+import "../LazyMerkleTree.sol";
+
+contract LazyMerkleTreeTest {
+    LazyTreeData public data;
+
+    function init(uint8 depth) public {
+        LazyMerkleTree.init(data, depth);
+    }
+
+    function reset() public {
+        LazyMerkleTree.reset(data);
+    }
+
+    function insert(uint256 leaf) public {
+        LazyMerkleTree.insert(data, leaf);
+    }
+
+    function update(uint256 leaf, uint40 index) public {
+        LazyMerkleTree.update(data, leaf, index);
+    }
+
+    function root() public view returns (uint256) {
+        return LazyMerkleTree.root(data);
+    }
+}

--- a/packages/incremental-merkle-tree.sol/hardhat.config.ts
+++ b/packages/incremental-merkle-tree.sol/hardhat.config.ts
@@ -5,6 +5,7 @@ import { resolve } from "path"
 import { config } from "./package.json"
 import "./tasks/deploy-ibt-test"
 import "./tasks/deploy-iqt-test"
+import "./tasks/deploy-lmt-test"
 
 dotenvConfig({ path: resolve(__dirname, "./.env") })
 

--- a/packages/incremental-merkle-tree.sol/tasks/deploy-lmt-test.ts
+++ b/packages/incremental-merkle-tree.sol/tasks/deploy-lmt-test.ts
@@ -1,0 +1,41 @@
+import { Contract } from "ethers"
+import { task, types } from "hardhat/config"
+
+task("deploy:lmt-test", "Deploy a LazyMerkleTree contract")
+    .addOptionalParam<boolean>("logs", "Print the logs", true, types.boolean)
+    .setAction(async ({ logs }, { ethers }): Promise<Contract> => {
+        const PoseidonT3Factory = await ethers.getContractFactory("PoseidonT3")
+        const PoseidonT3 = await PoseidonT3Factory.deploy()
+
+        if (logs) {
+            console.info(`PoseidonT3 library has been deployed to: ${PoseidonT3.address}`)
+        }
+
+        const LazyMerkleTreeFactory = await ethers.getContractFactory("LazyMerkleTree", {
+            libraries: {
+                PoseidonT3: PoseidonT3.address
+            }
+        })
+        const lazyMerkleTree = await LazyMerkleTreeFactory.deploy()
+
+        await lazyMerkleTree.deployed()
+
+        if (logs) {
+            console.info(`LazyMerkleTree library has been deployed to: ${lazyMerkleTree.address}`)
+        }
+
+        const ContractFactory = await ethers.getContractFactory("LazyMerkleTreeTest", {
+            libraries: {
+                LazyMerkleTree: lazyMerkleTree.address
+            }
+        })
+
+        const contract = await ContractFactory.deploy()
+
+        await contract.deployed()
+
+        if (logs) {
+            console.info(`Test contract has been deployed to: ${contract.address}`)
+        }
+        return { lazyMerkleTree, contract }
+    })

--- a/packages/incremental-merkle-tree.sol/tasks/deploy-lmt-test.ts
+++ b/packages/incremental-merkle-tree.sol/tasks/deploy-lmt-test.ts
@@ -1,11 +1,25 @@
 import { Contract } from "ethers"
 import { task, types } from "hardhat/config"
+import { proxy, PoseidonT3 } from "poseidon-solidity"
 
 task("deploy:lmt-test", "Deploy a LazyMerkleTree contract")
     .addOptionalParam<boolean>("logs", "Print the logs", true, types.boolean)
     .setAction(async ({ logs }, { ethers }): Promise<Contract> => {
-        const PoseidonT3Factory = await ethers.getContractFactory("PoseidonT3")
-        const PoseidonT3 = await PoseidonT3Factory.deploy()
+        // deterministically deploy PoseidonT3
+        const signer = await ethers.getSigner()
+        if ((await ethers.provider.getCode(proxy.address)) === "0x") {
+            await signer.sendTransaction({
+                to: proxy.from,
+                value: proxy.gas
+            })
+            await ethers.provider.sendTransaction(proxy.tx)
+        }
+        if ((await ethers.provider.getCode(PoseidonT3.address)) === "0x") {
+            await signer.sendTransaction({
+                to: proxy.address,
+                data: PoseidonT3.data
+            })
+        }
 
         if (logs) {
             console.info(`PoseidonT3 library has been deployed to: ${PoseidonT3.address}`)

--- a/packages/incremental-merkle-tree.sol/test/LazyMerkleTree.ts
+++ b/packages/incremental-merkle-tree.sol/test/LazyMerkleTree.ts
@@ -1,0 +1,190 @@
+import { expect } from "chai"
+import { run } from "hardhat"
+import { poseidon2 } from "poseidon-lite"
+import { IncrementalMerkleTree } from "@zk-kit/incremental-merkle-tree"
+
+const random = () => poseidon2([Math.floor(Math.random() * 2 ** 40), 0])
+
+/* eslint-disable jest/valid-expect */
+describe("LazyMerkleTree", function () {
+    this.timeout(100000)
+
+    it("should check zero values", async () => {
+        const { lazyMerkleTree } = await run("deploy:lmt-test", { logs: false })
+        expect("0").to.equal((await lazyMerkleTree.defaultZero(0)).toString())
+        let hash = poseidon2([0n, 0n])
+        for (let x = 1; x < 33; x += 1) {
+            const v = await lazyMerkleTree.defaultZero(x)
+            expect(v.toString()).to.equal(hash.toString())
+            hash = poseidon2([hash, hash])
+        }
+        await expect(lazyMerkleTree.defaultZero(34)).to.be.revertedWith("LazyMerkleTree: defaultZero bad index")
+    })
+
+    for (let x = 0; x < 32; x += 1) {
+        it(`should initialize tree with depth ${x}`, async () => {
+            const { contract } = await run("deploy:lmt-test", { logs: false })
+            {
+                const treeData = await contract.data()
+                expect(treeData.maxIndex).to.equal(0)
+                expect(treeData.numberOfLeaves).to.equal(0)
+            }
+            await contract.init(x)
+            {
+                const treeData = await contract.data()
+                expect(treeData.maxIndex).to.equal(2 ** x - 1)
+                expect(treeData.numberOfLeaves).to.equal(0)
+            }
+        })
+    }
+
+    // insertion tests
+
+    it("should fail to init large tree", async () => {
+        const { contract } = await run("deploy:lmt-test", { logs: false })
+        {
+            const treeData = await contract.data()
+            expect(treeData.maxIndex).to.equal(0)
+            expect(treeData.numberOfLeaves).to.equal(0)
+        }
+        await expect(contract.init(33)).to.be.revertedWith("LazyMerkleTree: Tree too large")
+    })
+
+    for (let depth = 1; depth < 6; depth += 1) {
+        it(`should insert leaves in tree with depth ${depth}`, async () => {
+            const { contract } = await run("deploy:lmt-test", { logs: false })
+            await contract.init(10)
+            // empty root should be H(0, 0)
+            expect(await contract.root()).to.equal(poseidon2([0n, 0n]))
+            const elements = []
+            for (let x = 0; x < 2 ** depth - 1; x += 1) {
+                const e = random()
+                elements.push(e)
+                // construct the tree
+                const targetDepth = Math.max(1, Math.ceil(Math.log2(elements.length)))
+                const merkleTree = new IncrementalMerkleTree(poseidon2, targetDepth, 0n)
+                for (const _e of elements) {
+                    merkleTree.insert(_e)
+                }
+                await contract.insert(e)
+                const root = await contract.root()
+                expect(root.toString()).to.equal(merkleTree.root.toString())
+                const treeData = await contract.data()
+                expect(treeData.numberOfLeaves).to.equal(elements.length)
+            }
+        })
+    }
+
+    it("should fail to insert too many leaves", async () => {
+        const { contract } = await run("deploy:lmt-test", { logs: false })
+        const depth = 5
+        await contract.init(depth)
+        for (let x = 0; x < 2 ** depth - 1; x += 1) {
+            await contract.insert(random())
+        }
+        await expect(contract.insert(random())).to.be.revertedWith("LazyMerkleTree: tree is full")
+    })
+
+    it("should fail to insert leaf outside of field", async () => {
+        const { contract, lazyMerkleTree } = await run("deploy:lmt-test", { logs: false })
+        const depth = 5
+        await contract.init(depth)
+        const F = await lazyMerkleTree.SNARK_SCALAR_FIELD()
+        await expect(contract.insert(F)).to.be.revertedWith("LazyMerkleTree: leaf must be < SNARK_SCALAR_FIELD")
+    })
+
+    // update tests
+
+    for (let depth = 1; depth < 5; depth += 1) {
+        it(`should update leaves in tree with depth ${depth}`, async () => {
+            const { contract } = await run("deploy:lmt-test", { logs: false })
+            await contract.init(depth)
+            const elements = []
+            // runs in ~N^N
+            for (let x = 0; x < 2 ** depth - 1; x += 1) {
+                const e = random()
+                elements.push(e)
+                // construct the tree
+                const targetDepth = Math.max(1, Math.ceil(Math.log2(elements.length)))
+                {
+                    const merkleTree = new IncrementalMerkleTree(poseidon2, targetDepth, 0n)
+                    for (const _e of elements) {
+                        merkleTree.insert(_e)
+                    }
+                    await contract.insert(e)
+                    const root = await contract.root()
+                    expect(root.toString()).to.equal(merkleTree.root.toString())
+                    const treeData = await contract.data()
+                    expect(treeData.numberOfLeaves).to.equal(elements.length)
+                }
+                for (let y = 0; y < x; y += 1) {
+                    const newE = random()
+                    elements.splice(y, 1, newE)
+                    await contract.update(newE, y)
+                    const merkleTree = new IncrementalMerkleTree(poseidon2, targetDepth, 0n)
+                    for (const _e of elements) {
+                        merkleTree.insert(_e)
+                    }
+                    const root = await contract.root()
+                    expect(root.toString()).to.equal(merkleTree.root.toString())
+                    const treeData = await contract.data()
+                    expect(treeData.numberOfLeaves).to.equal(elements.length)
+                }
+            }
+        })
+    }
+
+    it("should fail to update invalid leaf index", async () => {
+        const { contract } = await run("deploy:lmt-test", { logs: false })
+        const depth = 4
+        await contract.init(depth)
+        for (let x = 0; x < 10; x += 1) {
+            await contract.insert(random())
+        }
+        await expect(contract.update(random(), 10)).to.be.revertedWith("LazyMerkleTree: leaf must exist")
+    })
+
+    it("should fail to update with invalid leaf value", async () => {
+        const { contract, lazyMerkleTree } = await run("deploy:lmt-test", { logs: false })
+        const depth = 4
+        await contract.init(depth)
+        for (let x = 0; x < 3; x += 1) {
+            await contract.insert(random())
+        }
+        const F = await lazyMerkleTree.SNARK_SCALAR_FIELD()
+        await expect(contract.update(F, 0)).to.be.revertedWith("LazyMerkleTree: leaf must be < SNARK_SCALAR_FIELD")
+    })
+
+    it("should reset and reuse tree", async () => {
+        const { contract } = await run("deploy:lmt-test", { logs: false })
+        const depth = 4
+        await contract.init(10)
+        {
+            const data = await contract.data()
+            expect(data.numberOfLeaves).to.equal(0)
+        }
+        for (let i = 0; i < 3; i += 1) {
+            const elements = []
+            for (let x = 0; x < 2 ** depth - 1; x += 1) {
+                const e = random()
+                elements.push(e)
+                // construct the tree
+                const targetDepth = Math.max(1, Math.ceil(Math.log2(elements.length)))
+                const merkleTree = new IncrementalMerkleTree(poseidon2, targetDepth, 0n)
+                for (const _e of elements) {
+                    merkleTree.insert(_e)
+                }
+                await contract.insert(e)
+                const root = await contract.root()
+                expect(root.toString()).to.equal(merkleTree.root.toString())
+                const treeData = await contract.data()
+                expect(treeData.numberOfLeaves).to.equal(elements.length)
+            }
+            await contract.reset()
+            {
+                const data = await contract.data()
+                expect(data.numberOfLeaves).to.equal(0)
+            }
+        }
+    })
+})


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a `LazyMerkleTree` contract that builds a variable depth merkle tree. The depth increases as the tree becomes more full. The tree can have a max capacity set during initialization. The tree can also be reset and re-used in constant time.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
