### PR TITLE
Calculate root for variable heights

### DIFF
--- a/packages/incremental-merkle-tree.sol/contracts/LazyMerkleTree.sol
+++ b/packages/incremental-merkle-tree.sol/contracts/LazyMerkleTree.sol
@@ -93,7 +93,7 @@ library LazyMerkleTree {
 
     function root(LazyTreeData storage self, uint8 depth) public view returns (uint256) {
         uint40 numberOfLeaves = self.numberOfLeaves;
-        require(2**depth > numberOfLeaves, "LazyMerkleTree: ambiguous depth");
+        require(2**depth >= numberOfLeaves, "LazyMerkleTree: ambiguous depth");
         return _root(self, self.numberOfLeaves, depth);
     }
 

--- a/packages/incremental-merkle-tree.sol/contracts/test/LazyMerkleTreeTest.sol
+++ b/packages/incremental-merkle-tree.sol/contracts/test/LazyMerkleTreeTest.sol
@@ -33,6 +33,10 @@ contract LazyMerkleTreeTest {
         return LazyMerkleTree.root(data);
     }
 
+    function dynamicRoot(uint8 depth) public view returns (uint256) {
+        return LazyMerkleTree.root(data, depth);
+    }
+
     function staticRoot(uint8 depth) public view returns (uint256) {
         return LazyMerkleTree.root(data, depth);
     }

--- a/packages/incremental-merkle-tree.sol/contracts/test/LazyMerkleTreeTest.sol
+++ b/packages/incremental-merkle-tree.sol/contracts/test/LazyMerkleTreeTest.sol
@@ -23,6 +23,11 @@ contract LazyMerkleTreeTest {
         LazyMerkleTree.update(data, leaf, index);
     }
 
+    // for benchmarking the root cost
+    function benchmarkRoot() public {
+        LazyMerkleTree.root(data);
+    }
+
     function root() public view returns (uint256) {
         return LazyMerkleTree.root(data);
     }

--- a/packages/incremental-merkle-tree.sol/contracts/test/LazyMerkleTreeTest.sol
+++ b/packages/incremental-merkle-tree.sol/contracts/test/LazyMerkleTreeTest.sol
@@ -6,6 +6,7 @@ import "../LazyMerkleTree.sol";
 
 contract LazyMerkleTreeTest {
     LazyTreeData public data;
+    uint256 _root;
 
     function init(uint8 depth) public {
         LazyMerkleTree.init(data, depth);
@@ -25,10 +26,14 @@ contract LazyMerkleTreeTest {
 
     // for benchmarking the root cost
     function benchmarkRoot() public {
-        LazyMerkleTree.root(data);
+        _root = LazyMerkleTree.root(data);
     }
 
     function root() public view returns (uint256) {
         return LazyMerkleTree.root(data);
+    }
+
+    function staticRoot(uint8 depth) public view returns (uint256) {
+        return LazyMerkleTree.root(data, depth);
     }
 }

--- a/packages/incremental-merkle-tree.sol/test/LazyMerkleTree.ts
+++ b/packages/incremental-merkle-tree.sol/test/LazyMerkleTree.ts
@@ -69,8 +69,14 @@ describe("LazyMerkleTree", function () {
                     }
                     await contract.insert(e)
                     await contract.benchmarkRoot().then((t) => t.wait())
-                    const root = await contract.root()
-                    expect(root.toString()).to.equal(merkleTree.root.toString())
+                    {
+                        const root = await contract.root()
+                        expect(root.toString()).to.equal(merkleTree.root.toString())
+                    }
+                    {
+                        const root = await contract.dynamicRoot(targetDepth)
+                        expect(root.toString()).to.equal(merkleTree.root.toString())
+                    }
                 }
                 const treeData = await contract.data()
                 expect(treeData.numberOfLeaves).to.equal(elements.length)

--- a/packages/incremental-merkle-tree.sol/test/LazyMerkleTree.ts
+++ b/packages/incremental-merkle-tree.sol/test/LazyMerkleTree.ts
@@ -67,6 +67,7 @@ describe("LazyMerkleTree", function () {
                     merkleTree.insert(_e)
                 }
                 await contract.insert(e)
+                await contract.benchmarkRoot().then((t) => t.wait())
                 const root = await contract.root()
                 expect(root.toString()).to.equal(merkleTree.root.toString())
                 const treeData = await contract.data()
@@ -112,6 +113,7 @@ describe("LazyMerkleTree", function () {
                         merkleTree.insert(_e)
                     }
                     await contract.insert(e)
+                    await contract.benchmarkRoot().then((t) => t.wait())
                     const root = await contract.root()
                     expect(root.toString()).to.equal(merkleTree.root.toString())
                     const treeData = await contract.data()

--- a/packages/incremental-merkle-tree.sol/test/LazyMerkleTree.ts
+++ b/packages/incremental-merkle-tree.sol/test/LazyMerkleTree.ts
@@ -61,17 +61,27 @@ describe("LazyMerkleTree", function () {
                 const e = random()
                 elements.push(e)
                 // construct the tree
-                const targetDepth = Math.max(1, Math.ceil(Math.log2(elements.length)))
-                const merkleTree = new IncrementalMerkleTree(poseidon2, targetDepth, 0n)
-                for (const _e of elements) {
-                    merkleTree.insert(_e)
+                {
+                    const targetDepth = Math.max(1, Math.ceil(Math.log2(elements.length)))
+                    const merkleTree = new IncrementalMerkleTree(poseidon2, targetDepth, 0n)
+                    for (const _e of elements) {
+                        merkleTree.insert(_e)
+                    }
+                    await contract.insert(e)
+                    await contract.benchmarkRoot().then((t) => t.wait())
+                    const root = await contract.root()
+                    expect(root.toString()).to.equal(merkleTree.root.toString())
                 }
-                await contract.insert(e)
-                await contract.benchmarkRoot().then((t) => t.wait())
-                const root = await contract.root()
-                expect(root.toString()).to.equal(merkleTree.root.toString())
                 const treeData = await contract.data()
                 expect(treeData.numberOfLeaves).to.equal(elements.length)
+                for (let y = depth; y < 12; y += 1) {
+                    const merkleTree = new IncrementalMerkleTree(poseidon2, y, 0n)
+                    for (const _e of elements) {
+                        merkleTree.insert(_e)
+                    }
+                    const root = await contract.staticRoot(y)
+                    expect(root.toString()).to.equal(merkleTree.root.toString())
+                }
             }
         })
     }
@@ -188,5 +198,19 @@ describe("LazyMerkleTree", function () {
                 expect(data.numberOfLeaves).to.equal(0)
             }
         }
+    })
+
+    it("should fail to generate out of range static root", async () => {
+        const { contract } = await run("deploy:lmt-test", { logs: false })
+        await contract.init(10)
+
+        const elements = []
+        for (let x = 0; x < 20; x += 1) {
+            const e = random()
+            elements.push(e)
+            await contract.insert(e)
+        }
+        await expect(contract.staticRoot(4)).to.be.revertedWith("LazyMerkleTree: ambiguous depth")
+        await expect(contract.staticRoot(33)).to.be.revertedWith("LazyMerkleTree: depth must be < MAX_DEPTH")
     })
 })


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

Overloads the `root` function in `LazyMerkleTree` to accept an optional depth.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
