### PR TITLE
New NPM `types` field inside `exports`

### DIFF
--- a/packages/groth16/package.json
+++ b/packages/groth16/package.json
@@ -10,7 +10,8 @@
             "require": "./dist/index.node.js"
         },
         "browser": "./dist/index.browser.mjs",
-        "default": "./dist/index.browser.mjs"
+        "default": "./dist/index.browser.mjs",
+        "types": "./dist/types/index.d.ts"
     },
     "types": "dist/types/index.d.ts",
     "files": [

--- a/packages/imt/package.json
+++ b/packages/imt/package.json
@@ -9,7 +9,8 @@
     "main": "dist/index.node.js",
     "exports": {
         "import": "./dist/index.mjs",
-        "require": "./dist/index.node.js"
+        "require": "./dist/index.node.js",
+        "types": "./dist/types/index.d.ts"
     },
     "types": "dist/types/index.d.ts",
     "files": [

--- a/packages/lazytower/package.json
+++ b/packages/lazytower/package.json
@@ -9,7 +9,8 @@
     "main": "dist/index.node.js",
     "exports": {
         "import": "./dist/index.mjs",
-        "require": "./dist/index.node.js"
+        "require": "./dist/index.node.js",
+        "types": "./dist/types/index.d.ts"
     },
     "types": "dist/types/index.d.ts",
     "files": [

--- a/packages/poseidon-proof/package.json
+++ b/packages/poseidon-proof/package.json
@@ -10,7 +10,8 @@
             "require": "./dist/index.node.js"
         },
         "browser": "./dist/index.browser.mjs",
-        "default": "./dist/index.browser.mjs"
+        "default": "./dist/index.browser.mjs",
+        "types": "./dist/types/index.d.ts"
     },
     "types": "dist/types/index.d.ts",
     "files": [

--- a/packages/smt/package.json
+++ b/packages/smt/package.json
@@ -14,7 +14,8 @@
     "main": "dist/index.node.js",
     "exports": {
         "import": "./dist/index.mjs",
-        "require": "./dist/index.node.js"
+        "require": "./dist/index.node.js",
+        "types": "./dist/types/index.d.ts"
     },
     "types": "dist/types/index.d.ts",
     "files": [


### PR DESCRIPTION
## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #84 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
