### PR TITLE
fix(poseidon-cipher): fix depedency imports and add package to root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,34 @@
         </tr>
         <tr>
             <td>
+                <a href="https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/poseidon-cipher">
+                    @zk-kit/poseidon-cipher
+                </a>
+                 <a href="https://zkkit.pse.dev/modules/_zk_kit_poseidon-cipher.html">
+                    (docs)
+                </a>
+            </td>
+            <td>
+                <!-- NPM version -->
+                <a href="https://npmjs.org/package/@zk-kit/poseidon-cipher">
+                    <img src="https://img.shields.io/npm/v/@zk-kit/poseidon-cipher.svg?style=flat-square" alt="NPM version" />
+                </a>
+            </td>
+            <td>
+                <!-- Downloads -->
+                <a href="https://npmjs.org/package/@zk-kit/poseidon-cipher">
+                    <img src="https://img.shields.io/npm/dm/@zk-kit/poseidon-cipher.svg?style=flat-square" alt="Downloads" />
+                </a>
+            </td>
+            <td>
+                <!-- Size -->
+                <a href="https://bundlephobia.com/package/@zk-kit/poseidon-cipher">
+                    <img src="https://img.shields.io/bundlephobia/minzip/@zk-kit/poseidon-cipher" alt="npm bundle size (scoped)" />
+                </a>
+            </td>
+        </tr>
+        <tr>
+            <td>
                 <a href="https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/poseidon-proof">
                     @zk-kit/poseidon-proof
                 </a>

--- a/packages/poseidon-cipher/package.json
+++ b/packages/poseidon-cipher/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zk-kit/poseidon-cipher",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Poseidon encryption and decryption in TypeScript.",
     "license": "MIT",
     "keywords": [
@@ -40,13 +40,13 @@
         "access": "public"
     },
     "devDependencies": {
-        "@zk-kit/eddsa-poseidon": "workspace:^",
+        "@zk-kit/eddsa-poseidon": "0.1.0",
         "circomlibjs": "^0.0.8",
         "rollup-plugin-cleanup": "^3.2.1",
         "rollup-plugin-terser": "^7.0.2",
         "rollup-plugin-typescript2": "^0.32.1"
     },
     "dependencies": {
-        "@zk-kit/baby-jubjub": "workspace:^"
+        "@zk-kit/baby-jubjub": "0.1.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4438,7 +4438,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@zk-kit/baby-jubjub@0.1.0, @zk-kit/baby-jubjub@workspace:^, @zk-kit/baby-jubjub@workspace:packages/baby-jubjub":
+"@zk-kit/baby-jubjub@0.1.0, @zk-kit/baby-jubjub@workspace:packages/baby-jubjub":
   version: 0.0.0-use.local
   resolution: "@zk-kit/baby-jubjub@workspace:packages/baby-jubjub"
   dependencies:
@@ -4466,7 +4466,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@zk-kit/eddsa-poseidon@workspace:^, @zk-kit/eddsa-poseidon@workspace:packages/eddsa-poseidon":
+"@zk-kit/eddsa-poseidon@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@zk-kit/eddsa-poseidon@npm:0.1.0"
+  dependencies:
+    poseidon-lite: ^0.2.0
+  checksum: f87acefaf8a4195d1e0d6bc4cefdbd088900580616d2f23d04540f7687810774f2bccf0bc0332129c05eff1df76a96ed7f9b3f7107857f4d1be263729e92d186
+  languageName: node
+  linkType: hard
+
+"@zk-kit/eddsa-poseidon@workspace:packages/eddsa-poseidon":
   version: 0.0.0-use.local
   resolution: "@zk-kit/eddsa-poseidon@workspace:packages/eddsa-poseidon"
   dependencies:
@@ -4550,8 +4559,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@zk-kit/poseidon-cipher@workspace:packages/poseidon-cipher"
   dependencies:
-    "@zk-kit/baby-jubjub": "workspace:^"
-    "@zk-kit/eddsa-poseidon": "workspace:^"
+    "@zk-kit/baby-jubjub": 0.1.0
+    "@zk-kit/eddsa-poseidon": 0.1.0
     circomlibjs: ^0.0.8
     rollup-plugin-cleanup: ^3.2.1
     rollup-plugin-terser: ^7.0.2
@@ -4733,11 +4742,11 @@ __metadata:
   linkType: hard
 
 "acorn@npm:^8.2.4, acorn@npm:^8.4.1, acorn@npm:^8.8.2, acorn@npm:^8.9.0":
-  version: 8.11.2
-  resolution: "acorn@npm:8.11.2"
+  version: 8.11.3
+  resolution: "acorn@npm:8.11.3"
   bin:
     acorn: bin/acorn
-  checksum: 818450408684da89423e3daae24e4dc9b68692db8ab49ea4569c7c5abb7a3f23669438bf129cc81dfdada95e1c9b944ee1bfca2c57a05a4dc73834a612fbf6a7
+  checksum: 76d8e7d559512566b43ab4aadc374f11f563f0a9e21626dd59cb2888444e9445923ae9f3699972767f18af61df89cd89f5eaaf772d1327b055b45cb829b4a88c
   languageName: node
   linkType: hard
 
@@ -7115,13 +7124,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookies@npm:~0.8.0":
-  version: 0.8.0
-  resolution: "cookies@npm:0.8.0"
+"cookies@npm:~0.9.0":
+  version: 0.9.0
+  resolution: "cookies@npm:0.9.0"
   dependencies:
     depd: ~2.0.0
     keygrip: ~1.1.0
-  checksum: 806055a44f128705265b1bc6a853058da18bf80dea3654ad99be20985b1fa1b14f86c1eef73644aab8071241f8a78acd57202b54c4c5c70769fc694fbb9c4edc
+  checksum: e4db8b65edc85bb9640ddca88abae319cbde21af56d83b9b0a4346d41450166bc072f19d0eca00cc805be1c61979a6e80f7f38f5af517ffe2549a44ff5812953
   languageName: node
   linkType: hard
 
@@ -7140,11 +7149,11 @@ __metadata:
   linkType: hard
 
 "core-js-compat@npm:^3.31.0, core-js-compat@npm:^3.33.1":
-  version: 3.34.0
-  resolution: "core-js-compat@npm:3.34.0"
+  version: 3.35.0
+  resolution: "core-js-compat@npm:3.35.0"
   dependencies:
     browserslist: ^4.22.2
-  checksum: 6281f7f57a72f254c06611ec088445e11cf84e0b4edfb5f43dece1a1ff8b0ed0e81ed0bc291024761cd90c39d0f007d8bc46548265139808081d311c7cbc9c81
+  checksum: 64c41ce6870aa9130b9d0cb8f00c05204094f46db7e345d520ec2e38f8b6e1d51e921d4974ceb880948f19c0a79e5639e55be0e56f88ea20e32e9a6274da7f82
   languageName: node
   linkType: hard
 
@@ -13126,14 +13135,14 @@ __metadata:
   linkType: hard
 
 "koa@npm:^2.8.2":
-  version: 2.14.2
-  resolution: "koa@npm:2.14.2"
+  version: 2.15.0
+  resolution: "koa@npm:2.15.0"
   dependencies:
     accepts: ^1.3.5
     cache-content-type: ^1.0.0
     content-disposition: ~0.5.2
     content-type: ^1.0.4
-    cookies: ~0.8.0
+    cookies: ~0.9.0
     debug: ^4.3.2
     delegates: ^1.0.0
     depd: ^2.0.0
@@ -13152,7 +13161,7 @@ __metadata:
     statuses: ^1.5.0
     type-is: ^1.6.16
     vary: ^1.1.2
-  checksum: 17fe3b8f5e0b4759004a942cc6ba2a9507299943a697dff9766b85f41f45caed4077ca2645ac9ad254d3359fffedfc4c9ebdd7a70493e5df8cdfac159a8ee835
+  checksum: a97741f89f328f25ae94d82d0ee608377d89e086c73f2d868023e6050dea682ef93e0a5c80097f3aaad28121853aea50a7fb3c0c12ecc45798da2fd1255f580b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Fix workspace imports which cause the package to not be installed and add the package to the main README

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
