### PR TITLE
test: failing test for imt tree root

### DIFF
--- a/packages/imt.sol/test/LazyIMT.ts
+++ b/packages/imt.sol/test/LazyIMT.ts
@@ -113,6 +113,19 @@ describe("LazyIMT", () => {
             })
         }
 
+        it("Should insert multiple leaves", async () => {
+            const depth = 10
+
+            await lazyIMTTest.init(depth)
+
+            for (let x = 0; x < 129; x += 1) {
+                await lazyIMTTest.insert(random())
+            }
+
+            let root = await lazyIMTTest.root()
+            console.log("root: ", root.toString())
+        })
+
         it("Should fail to insert too many leaves", async () => {
             const depth = 3
 


### PR DESCRIPTION
## Description

This PR adds a failing test for the LazyIMT tree that would be expected to pass. When creating a tree with more than 128 elements inserted, when checking its `root()` the transaction reverts with the following error. With `128` it works, with `129` (and more) it fails. Note that in both cases, the `depth` of the tree is enough to fit all elements.

```
 Error: call revert exception; VM Exception while processing transaction: reverted with panic code 17 [ See: https://links.ethers.org/v5-errors-CALL_EXCEPTION ] (method="root()", data="0x4e487b710000000000000000000000000000000000000000000000000000000000000011", errorArgs=[{"type":"BigNumber","hex":"0x11"}], errorName="Panic", errorSignature="Panic(uint256)", reason=null, code=CALL_EXCEPTION, version=abi/5.7.0)
```

It this expected?