### PR TITLE
fix: lazy imt depth overflow

### DIFF
--- a/packages/imt.sol/contracts/internal/InternalLazyIMT.sol
+++ b/packages/imt.sol/contracts/internal/InternalLazyIMT.sol
@@ -151,20 +151,23 @@ library InternalLazyIMT {
         uint40 numberOfLeaves = self.numberOfLeaves;
         // dynamically determine a depth
         uint8 depth = 1;
-        while (uint8(2) ** depth < numberOfLeaves) {
+        while (uint32(2) ** uint32(depth) < numberOfLeaves) {
             depth++;
         }
         return _root(self, numberOfLeaves, depth);
     }
 
     function _root(LazyIMTData storage self, uint8 depth) internal view returns (uint256) {
+        require(depth > 0, "LazyIMT: depth must be > 0");
+        require(depth <= MAX_DEPTH, "LazyIMT: depth must be < MAX_DEPTH");
         uint40 numberOfLeaves = self.numberOfLeaves;
-        require(2 ** depth >= numberOfLeaves, "LazyIMT: ambiguous depth");
-        return _root(self, self.numberOfLeaves, depth);
+        require(uint32(2) ** uint32(depth) >= numberOfLeaves, "LazyIMT: ambiguous depth");
+        return _root(self, numberOfLeaves, depth);
     }
 
+    // Here it's assumed that the depth value is valid. If it is either 0 or > 2^8-1
+    // this function will panic.
     function _root(LazyIMTData storage self, uint40 numberOfLeaves, uint8 depth) internal view returns (uint256) {
-        require(depth > 0, "LazyIMT: depth must be > 0");
         require(depth <= MAX_DEPTH, "LazyIMT: depth must be < MAX_DEPTH");
         // this should always short circuit if self.numberOfLeaves == 0
         if (numberOfLeaves == 0) return _defaultZero(depth);

--- a/packages/imt.sol/contracts/internal/InternalLazyIMT.sol
+++ b/packages/imt.sol/contracts/internal/InternalLazyIMT.sol
@@ -159,7 +159,7 @@ library InternalLazyIMT {
 
     function _root(LazyIMTData storage self, uint8 depth) internal view returns (uint256) {
         require(depth > 0, "LazyIMT: depth must be > 0");
-        require(depth <= MAX_DEPTH, "LazyIMT: depth must be < MAX_DEPTH");
+        require(depth <= MAX_DEPTH, "LazyIMT: depth must be <= MAX_DEPTH");
         uint40 numberOfLeaves = self.numberOfLeaves;
         require(uint32(2) ** uint32(depth) >= numberOfLeaves, "LazyIMT: ambiguous depth");
         return _root(self, numberOfLeaves, depth);
@@ -168,7 +168,7 @@ library InternalLazyIMT {
     // Here it's assumed that the depth value is valid. If it is either 0 or > 2^8-1
     // this function will panic.
     function _root(LazyIMTData storage self, uint40 numberOfLeaves, uint8 depth) internal view returns (uint256) {
-        require(depth <= MAX_DEPTH, "LazyIMT: depth must be < MAX_DEPTH");
+        require(depth <= MAX_DEPTH, "LazyIMT: depth must be <= MAX_DEPTH");
         // this should always short circuit if self.numberOfLeaves == 0
         if (numberOfLeaves == 0) return _defaultZero(depth);
         uint40 index = numberOfLeaves - 1;

--- a/packages/imt.sol/contracts/internal/InternalLazyIMT.sol
+++ b/packages/imt.sol/contracts/internal/InternalLazyIMT.sol
@@ -5,7 +5,7 @@ import {PoseidonT3} from "poseidon-solidity/PoseidonT3.sol";
 import {SNARK_SCALAR_FIELD, MAX_DEPTH} from "../Constants.sol";
 
 struct LazyIMTData {
-    uint32 maxIndex;
+    uint40 maxIndex;
     uint40 numberOfLeaves;
     mapping(uint256 => uint256) elements;
 }
@@ -86,7 +86,7 @@ library InternalLazyIMT {
 
     function _init(LazyIMTData storage self, uint8 depth) internal {
         require(depth <= MAX_DEPTH, "LazyIMT: Tree too large");
-        self.maxIndex = uint32((1 << depth) - 1);
+        self.maxIndex = uint40((1 << depth) - 1);
         self.numberOfLeaves = 0;
     }
 
@@ -151,7 +151,7 @@ library InternalLazyIMT {
         uint40 numberOfLeaves = self.numberOfLeaves;
         // dynamically determine a depth
         uint8 depth = 1;
-        while (uint32(2) ** uint32(depth) < numberOfLeaves) {
+        while (uint40(2) ** uint40(depth) < numberOfLeaves) {
             depth++;
         }
         return _root(self, numberOfLeaves, depth);
@@ -161,7 +161,7 @@ library InternalLazyIMT {
         require(depth > 0, "LazyIMT: depth must be > 0");
         require(depth <= MAX_DEPTH, "LazyIMT: depth must be <= MAX_DEPTH");
         uint40 numberOfLeaves = self.numberOfLeaves;
-        require(uint32(2) ** uint32(depth) >= numberOfLeaves, "LazyIMT: ambiguous depth");
+        require(uint40(2) ** uint40(depth) >= numberOfLeaves, "LazyIMT: ambiguous depth");
         return _root(self, numberOfLeaves, depth);
     }
 

--- a/packages/imt.sol/test/LazyIMT.ts
+++ b/packages/imt.sol/test/LazyIMT.ts
@@ -113,6 +113,19 @@ describe("LazyIMT", () => {
             })
         }
 
+        it("Should insert multiple leaves", async () => {
+            const depth = 10
+
+            await lazyIMTTest.init(depth)
+
+            for (let x = 0; x < 129; x += 1) {
+                await lazyIMTTest.insert(random())
+            }
+
+            let root = await lazyIMTTest.root()
+            console.log("root: ", root.toString())
+        })
+
         it("Should fail to insert too many leaves", async () => {
             const depth = 3
 

--- a/packages/imt.sol/test/LazyIMT.ts
+++ b/packages/imt.sol/test/LazyIMT.ts
@@ -283,6 +283,6 @@ describe("LazyIMT", () => {
             await lazyIMTTest.insert(e)
         }
         await expect(lazyIMTTest.staticRoot(4)).to.be.revertedWith("LazyIMT: ambiguous depth")
-        await expect(lazyIMTTest.staticRoot(33)).to.be.revertedWith("LazyIMT: depth must be < MAX_DEPTH")
+        await expect(lazyIMTTest.staticRoot(33)).to.be.revertedWith("LazyIMT: depth must be <= MAX_DEPTH")
     })
 })

--- a/packages/imt.sol/test/LazyIMT.ts
+++ b/packages/imt.sol/test/LazyIMT.ts
@@ -114,16 +114,19 @@ describe("LazyIMT", () => {
         }
 
         it("Should insert multiple leaves", async () => {
-            const depth = 10
+            const depth = 8
 
+            const merkleTree = new IMT(poseidon2, depth, BigInt(0))
             await lazyIMTTest.init(depth)
 
-            for (let x = 0; x < 129; x += 1) {
-                await lazyIMTTest.insert(random())
+            for (let x = 0; x < 130; x += 1) {
+                const e = random()
+                await lazyIMTTest.insert(e)
+                merkleTree.insert(e)
             }
 
-            let root = await lazyIMTTest.root()
-            console.log("root: ", root.toString())
+            const root = await lazyIMTTest.root()
+            expect(root.toString()).to.equal(merkleTree.root.toString())
         })
 
         it("Should fail to insert too many leaves", async () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes an overflow when checking number of leaves for a depth.

## Related Issue

Related #135 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
