### PR TITLE
feat(poseidon-cipher): add decrypt without checks to not throw on failure

### DIFF
--- a/packages/poseidon-cipher/package.json
+++ b/packages/poseidon-cipher/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zk-kit/poseidon-cipher",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "description": "Poseidon encryption and decryption in TypeScript.",
     "license": "MIT",
     "keywords": [

--- a/packages/poseidon-cipher/tests/index.test.ts
+++ b/packages/poseidon-cipher/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { poseidonDecrypt, poseidonEncrypt } from "../src/poseidonCipher"
+import { poseidonDecrypt, poseidonDecryptWithoutCheck, poseidonEncrypt } from "../src/poseidonCipher"
 import { Nonce, PlainText } from "../src/types"
 import { genEcdhSharedKey, genPublicKey, genRandomBabyJubValue } from "./utils"
 
@@ -39,6 +39,32 @@ describe("Poseidon Cipher", () => {
             expect(() => poseidonDecrypt(cipherText, [BigInt(0), BigInt(0)], nonce, plainText.length)).toThrow(
                 "The last element of the message must be 0"
             )
+        })
+    })
+
+    describe("poseidonDecryptWithoutCheck", () => {
+        it("Should produce the correct plaintext given a ciphertext and key", () => {
+            const cipherText = poseidonEncrypt(plainText, encryptionKey, nonce)
+            const decryptedPlainText = poseidonDecryptWithoutCheck(cipherText, encryptionKey, nonce, plainText.length)
+            expect(decryptedPlainText).toStrictEqual(plainText)
+        })
+
+        it("Should not throw when given an invalid key and the plaintext length % 3 is 2", () => {
+            const plainText: PlainText<bigint> = new Array(8).fill(BigInt(0))
+            const cipherText = poseidonEncrypt(plainText, encryptionKey, nonce)
+
+            expect(() =>
+                poseidonDecryptWithoutCheck(cipherText, [BigInt(0), BigInt(0)], nonce, plainText.length)
+            ).not.toThrow("The last element of the message must be 0")
+        })
+
+        it("Should not throw when given an invalid key and the plaintext length % 3 is 1", () => {
+            const plainText: PlainText<bigint> = new Array(7).fill(BigInt(0))
+            const cipherText = poseidonEncrypt(plainText, encryptionKey, nonce)
+
+            expect(() =>
+                poseidonDecryptWithoutCheck(cipherText, [BigInt(0), BigInt(0)], nonce, plainText.length)
+            ).not.toThrow("The last element of the message must be 0")
         })
     })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4453,6 +4453,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@zk-kit/baby-jubjub@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@zk-kit/baby-jubjub@npm:0.1.0"
+  dependencies:
+    "@zk-kit/utils": 0.1.0
+  checksum: 73d3c03c276c4752d0582e2fadc03dc1a78ee3b869a7944cfec7f121df7bdad8d96caefab3eb3acdf7f6d10d5945bfc42307979ddbc6fd54c451a312509e1c16
+  languageName: node
+  linkType: hard
+
 "@zk-kit/circuits@workspace:packages/circuits":
   version: 0.0.0-use.local
   resolution: "@zk-kit/circuits@workspace:packages/circuits"
@@ -4558,7 +4567,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@zk-kit/poseidon-cipher@0.1.1, @zk-kit/poseidon-cipher@workspace:packages/poseidon-cipher":
+"@zk-kit/poseidon-cipher@npm:0.1.1":
+  version: 0.1.1
+  resolution: "@zk-kit/poseidon-cipher@npm:0.1.1"
+  dependencies:
+    "@zk-kit/baby-jubjub": 0.1.0
+  checksum: d7e08976a26d85bbf864ff90b8eb1e0d490286d384ca29f37c845c0f515dcf187186f33bd9b1cda595ca50031b0d9c787ba92ea40c358e16e4ab775ead4d58a3
+  languageName: node
+  linkType: hard
+
+"@zk-kit/poseidon-cipher@workspace:packages/poseidon-cipher":
   version: 0.0.0-use.local
   resolution: "@zk-kit/poseidon-cipher@workspace:packages/poseidon-cipher"
   dependencies:


### PR DESCRIPTION
## Description

Implement copy of circuit.decryptWithoutCheck to replicate circuit logic in TS.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
