### PR TITLE
fix(utils): input mutations and small-number padding in BigInt <-> Buffer conversions

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -33,6 +33,7 @@
         "access": "public"
     },
     "devDependencies": {
+        "@types/chai": "^4.2.0",
         "rollup-plugin-cleanup": "^3.2.1",
         "rollup-plugin-polyfill-node": "^0.13.0",
         "rollup-plugin-terser": "^7.0.2",

--- a/packages/utils/src/number-conversions.ts
+++ b/packages/utils/src/number-conversions.ts
@@ -30,6 +30,18 @@ export function bufferToBigint(buffer: Buffer): bigint {
     return BigInt(`0x${buffer.toString("hex")}`)
 }
 
+export function bigintToBuffer(n: bigint): Buffer {
+    const hex = bigintToHexadecimal(n)
+
+    // Allocate buffer of the desired size, filled with zeros.
+    const buffer = Buffer.alloc(32, 0)
+
+    const fromHex = Buffer.from(hex, "hex")
+    fromHex.copy(buffer, 32 - fromHex.length)
+
+    return buffer
+}
+
 export function bigNumberishToBigint(value: BigNumberish): bigint {
     if (
         typeof value === "number" ||
@@ -44,7 +56,7 @@ export function bigNumberishToBigint(value: BigNumberish): bigint {
 }
 
 export function leBufferToBigint(buffer: Buffer): bigint {
-    return BigInt(`0x${buffer.reverse().toString("hex")}`)
+    return BigInt(`0x${Buffer.from(buffer).reverse().toString("hex")}`)
 }
 
 export function leBigintToBuffer(n: bigint): Buffer {
@@ -53,7 +65,8 @@ export function leBigintToBuffer(n: bigint): Buffer {
     // Allocate buffer of the desired size, filled with zeros.
     const buffer = Buffer.alloc(32, 0)
 
-    Buffer.from(hex, "hex").reverse().copy(buffer)
+    const fromHex = Buffer.from(hex, "hex").reverse()
+    fromHex.copy(buffer, 0)
 
     return buffer
 }

--- a/packages/utils/tests/number-conversions.test.ts
+++ b/packages/utils/tests/number-conversions.test.ts
@@ -1,0 +1,58 @@
+import { expect } from "chai"
+import { bufferToBigint, bigintToBuffer, leBigintToBuffer, leBufferToBigint } from "../src/number-conversions"
+
+describe("Number Conversions", () => {
+    describe("Bigint to/from Buffer Conversions", () => {
+        const tesetBytes1 = [
+          0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+          0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+          0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+          0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
+        ]
+        const testNum1LE = BigInt("0x1F1E1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403020100");
+        const testNum1BE = BigInt("0x000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F");
+
+        it("Should support little-endian conversions", async () => {
+          const in1 = Buffer.from(tesetBytes1)
+          const n1 = leBufferToBigint(in1)
+          expect(n1).to.be.eq(testNum1LE)
+          const out1 = leBigintToBuffer(n1)
+          expect(out1.length).to.eq(32)
+          expect(out1).to.deep.eq(Buffer.from(tesetBytes1))
+        })
+
+        it("Should support big-endian conversions", async () => {
+          const in1 = Buffer.from(tesetBytes1)
+          const n1 = bufferToBigint(in1)
+          expect(n1).to.be.eq(testNum1BE)
+          const out1 = bigintToBuffer(n1)
+          expect(out1.length).to.eq(32)
+          expect(out1).to.deep.eq(Buffer.from(tesetBytes1))
+        })
+
+        it("Should pad small numbers", async () => {
+          const smallBufLE = leBigintToBuffer(BigInt(0x020100))
+          expect(smallBufLE).to.have.length(32)
+          const smallOutLE = leBufferToBigint(smallBufLE)
+          expect(smallOutLE).to.eq(BigInt(0x020100))
+
+          const smallBufBE = bigintToBuffer(BigInt(0x020100))
+          expect(smallBufBE).to.have.length(32)
+          const smallOutBE = bufferToBigint(smallBufBE)
+          expect(smallOutBE).to.eq(BigInt(0x020100))
+        })
+
+        it("Should not mutate input buffers", async () => {
+          const in1 = Buffer.from(tesetBytes1)
+          expect(in1).to.deep.eq(Buffer.from(tesetBytes1))
+
+          const n1LE = leBufferToBigint(in1)
+          expect(n1LE).to.eq(testNum1LE)
+          expect(in1).to.deep.eq(Buffer.from(tesetBytes1))
+
+          const n1BE = bufferToBigint(in1)
+          expect(n1BE).to.eq(testNum1BE)
+          expect(in1).to.deep.eq(Buffer.from(tesetBytes1))
+        })
+      })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -4642,6 +4642,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@zk-kit/utils@workspace:packages/utils"
   dependencies:
+    "@types/chai": ^4.2.0
     rollup-plugin-cleanup: ^3.2.1
     rollup-plugin-polyfill-node: ^0.13.0
     rollup-plugin-terser: ^7.0.2


### PR DESCRIPTION
## Description

4 changes here, in order of importance:

1) While testing compatibility of zk-kit with circomlibjs, I discovered that `leBufferToBigint` has a side-effect of reversing its input.  This was surprising when I was trying to use the same input multiple times and compare results.  Fixing this introduces an extra copy of 32 bytes, but I think that's worthwhile to avoid the risk of bugs.  There are larger costs for the use of hex coversion via strings.

2) While testing this, I also noticed that `bigintToBuffer` doesn't always pad its results to 32 bytes, resulting in incorrect conversions.  I fixed this as well using an offset to the copy command.  These conversion functions seem to be intended for fixed-size numbers of 32 byes.  I'd recommend adding some more checks that input bigints aren't too large for this size, but I didn't try to tackle that in this PR.

3) I added `bufferToBigint` for symmetry, so utils can convert between Buffer and BigInt in both directions with either endinness.  This is mostly so my tests can be complete.

4) I added tests of the 4 conversion functions, including tests which demonstrate the bugs I fixed.  Note that I was told that `utils` tests are disabled in `jest.config.ts` because they are incomplete.  I enabled them locally so I could run my tests, then disabled them again when I was done, so that you can complete the rest of them on your own schedule.

## Related Issue

Fixes #147
Fixes #148

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

## Other information

Note that the contribution guidelines say to submit a PR for the `dev` branch.  That doesn't seem to exist (or isn't visible to me) so I'm targeting `main`.

You can see some additional discussion on these issues (and others) between me and @cedoor on the #zk-kit channel of the PSE discord.

I work on Zupass at 0xPARC, and am in the process of evaluating zk-kit for use in some new PCDs.
