### PR TITLE
feat: add get merkle proof to lazy imt tree

### DIFF
--- a/packages/imt.sol/contracts/LazyIMT.sol
+++ b/packages/imt.sol/contracts/LazyIMT.sol
@@ -38,11 +38,19 @@ library LazyIMT {
         return InternalLazyIMT._root(self, depth);
     }
 
-    function merkleProofElements(LazyIMTData storage self, uint40 index, uint8 depth) public view returns (uint256[] memory) {
+    function merkleProofElements(
+        LazyIMTData storage self,
+        uint40 index,
+        uint8 depth
+    ) public view returns (uint256[] memory) {
         return InternalLazyIMT._merkleProofElements(self, index, depth);
     }
 
-    function merkleProofIndexes(LazyIMTData storage self, uint40 index, uint8 depth) public view returns (bool[] memory) {
+    function merkleProofIndexes(
+        LazyIMTData storage self,
+        uint40 index,
+        uint8 depth
+    ) public view returns (bool[] memory) {
         return InternalLazyIMT._merkleProofIndexes(self, index, depth);
     }
 

--- a/packages/imt.sol/contracts/LazyIMT.sol
+++ b/packages/imt.sol/contracts/LazyIMT.sol
@@ -38,6 +38,14 @@ library LazyIMT {
         return InternalLazyIMT._root(self, depth);
     }
 
+    function merkleProofElements(LazyIMTData storage self, uint40 index, uint8 depth) public view returns (uint256[] memory) {
+        return InternalLazyIMT._merkleProofElements(self, index, depth);
+    }
+
+    function merkleProofIndexes(LazyIMTData storage self, uint40 index, uint8 depth) public view returns (bool[] memory) {
+        return InternalLazyIMT._merkleProofIndexes(self, index, depth);
+    }
+
     function _root(LazyIMTData storage self, uint40 numberOfLeaves, uint8 depth) internal view returns (uint256) {
         return InternalLazyIMT._root(self, numberOfLeaves, depth);
     }

--- a/packages/imt.sol/contracts/LazyIMT.sol
+++ b/packages/imt.sol/contracts/LazyIMT.sol
@@ -46,14 +46,6 @@ library LazyIMT {
         return InternalLazyIMT._merkleProofElements(self, index, depth);
     }
 
-    function merkleProofIndexes(
-        LazyIMTData storage self,
-        uint40 index,
-        uint8 depth
-    ) public view returns (bool[] memory) {
-        return InternalLazyIMT._merkleProofIndexes(self, index, depth);
-    }
-
     function _root(LazyIMTData storage self, uint40 numberOfLeaves, uint8 depth) internal view returns (uint256) {
         return InternalLazyIMT._root(self, numberOfLeaves, depth);
     }

--- a/packages/imt.sol/contracts/internal/InternalLazyIMT.sol
+++ b/packages/imt.sol/contracts/internal/InternalLazyIMT.sol
@@ -157,8 +157,11 @@ library InternalLazyIMT {
         return _root(self, numberOfLeaves, depth);
     }
 
-    function _merkleProofElements(LazyIMTData storage self, uint40 index, uint8 depth)
-                                  internal view returns (uint256[] memory) {
+    function _merkleProofElements(
+        LazyIMTData storage self,
+        uint40 index,
+        uint8 depth
+    ) internal view returns (uint256[] memory) {
         uint40 numberOfLeaves = self.numberOfLeaves;
         require(index < numberOfLeaves, "LazyIMT: leaf must exist");
         require(depth > 0, "LazyIMT: depth must be > 0");
@@ -170,17 +173,16 @@ library InternalLazyIMT {
         for (uint8 i = 0; i < depth; ) {
             // Left leaf
             if (index & 1 == 0) {
-                bool outsideLimits = ((index+1) << i) % self.numberOfLeaves != 0;
+                bool outsideLimits = ((index + 1) << i) % self.numberOfLeaves != 0;
                 if ((index + 1) < levelCount) {
                     proof[i] = self.elements[_indexForElement(i, index + 1)];
-                } else if (((index+1) == levelCount) && (outsideLimits)) {
+                } else if (((index + 1) == levelCount) && (outsideLimits)) {
                     proof[i] = _root(self, numberOfLeaves, i);
                 } else {
                     proof[i] = _defaultZero(i);
                 }
-            // Right leaf
             } else {
-                proof[i] = self.elements[_indexForElement(i, index -1)];
+                proof[i] = self.elements[_indexForElement(i, index - 1)];
             }
             unchecked {
                 index >>= 1;
@@ -191,8 +193,11 @@ library InternalLazyIMT {
         return proof;
     }
 
-    function _merkleProofIndexes(LazyIMTData storage self, uint40 index, uint8 depth)
-                                 internal view returns (bool[] memory) {
+    function _merkleProofIndexes(
+        LazyIMTData storage self,
+        uint40 index,
+        uint8 depth
+    ) internal view returns (bool[] memory) {
         uint40 numberOfLeaves = self.numberOfLeaves;
         require(index < numberOfLeaves, "LazyIMT: leaf must exist");
         require(depth > 0, "LazyIMT: depth must be > 0");
@@ -206,7 +211,6 @@ library InternalLazyIMT {
                 // Left leaf
                 if (index & 1 == 0) {
                     proofIndexes[i] = false;
-                // Right leaf
                 } else {
                     proofIndexes[i] = true;
                 }

--- a/packages/imt.sol/contracts/internal/InternalLazyIMT.sol
+++ b/packages/imt.sol/contracts/internal/InternalLazyIMT.sol
@@ -157,74 +157,6 @@ library InternalLazyIMT {
         return _root(self, numberOfLeaves, depth);
     }
 
-    function _merkleProofElements(
-        LazyIMTData storage self,
-        uint40 index,
-        uint8 depth
-    ) internal view returns (uint256[] memory) {
-        uint40 numberOfLeaves = self.numberOfLeaves;
-        require(index < numberOfLeaves, "LazyIMT: leaf must exist");
-        require(depth > 0, "LazyIMT: depth must be > 0");
-        require(depth <= MAX_DEPTH, "LazyIMT: depth must be < MAX_DEPTH");
-
-        uint256[] memory proof = new uint256[](depth);
-        uint256 levelCount = self.numberOfLeaves;
-
-        for (uint8 i = 0; i < depth; ) {
-            // Left leaf
-            if (index & 1 == 0) {
-                bool outsideLimits = ((index + 1) << i) % self.numberOfLeaves != 0;
-                if ((index + 1) < levelCount) {
-                    proof[i] = self.elements[_indexForElement(i, index + 1)];
-                } else if (((index + 1) == levelCount) && (outsideLimits)) {
-                    proof[i] = _root(self, numberOfLeaves, i);
-                } else {
-                    proof[i] = _defaultZero(i);
-                }
-            } else {
-                proof[i] = self.elements[_indexForElement(i, index - 1)];
-            }
-            unchecked {
-                index >>= 1;
-                i++;
-            }
-            levelCount = numberOfLeaves >> i;
-        }
-        return proof;
-    }
-
-    function _merkleProofIndexes(
-        LazyIMTData storage self,
-        uint40 index,
-        uint8 depth
-    ) internal view returns (bool[] memory) {
-        uint40 numberOfLeaves = self.numberOfLeaves;
-        require(index < numberOfLeaves, "LazyIMT: leaf must exist");
-        require(depth > 0, "LazyIMT: depth must be > 0");
-        require(depth <= MAX_DEPTH, "LazyIMT: depth must be < MAX_DEPTH");
-
-        bool[] memory proofIndexes = new bool[](depth);
-
-        uint256 levelCount = self.numberOfLeaves;
-        for (uint8 i = 0; i < depth; ) {
-            if (levelCount > index >> 1) {
-                // Left leaf
-                if (index & 1 == 0) {
-                    proofIndexes[i] = false;
-                } else {
-                    proofIndexes[i] = true;
-                }
-            }
-
-            unchecked {
-                index >>= 1;
-                i++;
-            }
-            levelCount = numberOfLeaves >> i;
-        }
-        return proofIndexes;
-    }
-
     function _root(LazyIMTData storage self, uint8 depth) internal view returns (uint256) {
         require(depth > 0, "LazyIMT: depth must be > 0");
         require(depth <= MAX_DEPTH, "LazyIMT: depth must be <= MAX_DEPTH");
@@ -268,5 +200,41 @@ library InternalLazyIMT {
             }
         }
         return levels[depth];
+    }
+
+    function _merkleProofElements(
+        LazyIMTData storage self,
+        uint40 index,
+        uint8 depth
+    ) internal view returns (uint256[] memory) {
+        uint40 numberOfLeaves = self.numberOfLeaves;
+        require(index < numberOfLeaves, "LazyIMT: leaf must exist");
+        require(depth > 0, "LazyIMT: depth must be > 0");
+        require(depth <= MAX_DEPTH, "LazyIMT: depth must be < MAX_DEPTH");
+
+        uint256[] memory proof = new uint256[](depth);
+        uint256 levelCount = self.numberOfLeaves;
+
+        for (uint8 i = 0; i < depth; ) {
+            // Left leaf
+            if (index & 1 == 0) {
+                bool outsideLimits = ((index + 1) << i) % self.numberOfLeaves != 0;
+                if ((index + 1) < levelCount) {
+                    proof[i] = self.elements[_indexForElement(i, index + 1)];
+                } else if (((index + 1) == levelCount) && (outsideLimits)) {
+                    proof[i] = _root(self, numberOfLeaves, i);
+                } else {
+                    proof[i] = _defaultZero(i);
+                }
+            } else {
+                proof[i] = self.elements[_indexForElement(i, index - 1)];
+            }
+            unchecked {
+                index >>= 1;
+                i++;
+            }
+            levelCount = numberOfLeaves >> i;
+        }
+        return proof;
     }
 }

--- a/packages/imt.sol/contracts/internal/InternalLazyIMT.sol
+++ b/packages/imt.sol/contracts/internal/InternalLazyIMT.sol
@@ -176,7 +176,12 @@ library InternalLazyIMT {
         return levels[depth];
     }
 
-    function _levels(LazyIMTData storage self, uint40 numberOfLeaves, uint8 depth, uint256[] memory levels) internal view {
+    function _levels(
+        LazyIMTData storage self,
+        uint40 numberOfLeaves,
+        uint8 depth,
+        uint256[] memory levels
+    ) internal view {
         require(depth <= MAX_DEPTH, "LazyIMT: depth must be <= MAX_DEPTH");
         require(numberOfLeaves > 0, "LazyIMT: number of leaves must be > 0");
         // this should always short circuit if self.numberOfLeaves == 0
@@ -246,7 +251,7 @@ library InternalLazyIMT {
                 // otherwise set as usual below
                 if (index + 1 < currentLevelCount) {
                     _elements[i] = self.elements[_indexForElement(i, index + 1)];
-                } else if ((numberOfLeaves - 1 >> i) <= index) {
+                } else if (((numberOfLeaves - 1) >> i) <= index) {
                     _elements[i] = _defaultZero(i);
                 }
             } else {

--- a/packages/imt.sol/contracts/test/LazyIMTTest.sol
+++ b/packages/imt.sol/contracts/test/LazyIMTTest.sol
@@ -44,8 +44,4 @@ contract LazyIMTTest {
     function merkleProofElements(uint40 index, uint8 depth) public view returns (uint256[] memory) {
         return LazyIMT.merkleProofElements(data, index, depth);
     }
-
-    function merkleProofIndexes(uint40 index, uint8 depth) public view returns (bool[] memory) {
-        return LazyIMT.merkleProofIndexes(data, index, depth);
-    }
 }

--- a/packages/imt.sol/contracts/test/LazyIMTTest.sol
+++ b/packages/imt.sol/contracts/test/LazyIMTTest.sol
@@ -40,4 +40,12 @@ contract LazyIMTTest {
     function staticRoot(uint8 depth) public view returns (uint256) {
         return LazyIMT.root(data, depth);
     }
+
+    function merkleProofElements(uint40 index, uint8 depth) public view returns (uint256[] memory) {
+        return LazyIMT.merkleProofElements(data, index, depth);
+    }
+
+    function merkleProofIndexes(uint40 index, uint8 depth) public view returns (bool[] memory) {
+        return LazyIMT.merkleProofIndexes(data, index, depth);
+    }
 }

--- a/packages/imt.sol/test/LazyIMT.ts
+++ b/packages/imt.sol/test/LazyIMT.ts
@@ -295,7 +295,7 @@ describe("LazyIMT", () => {
         function calculateRoot(leafIndex: number, leaf: BigNumber, proofElements: BigNumber[]) {
             let hash = leaf
             const proofIndexes = []
-            for (let x = 0; x < proofElements.length; x+=1) {
+            for (let x = 0; x < proofElements.length; x += 1) {
                 proofIndexes.push((leafIndex >> x) & 1)
             }
             for (let i = 0; i < proofElements.length; i += 1) {

--- a/packages/imt.sol/test/LazyIMT.ts
+++ b/packages/imt.sol/test/LazyIMT.ts
@@ -4,12 +4,13 @@ import { poseidon2 } from "poseidon-lite"
 import { IMT } from "@zk-kit/imt"
 import type { BigNumber } from "ethers"
 import { LazyIMT, LazyIMTTest } from "../typechain-types"
+
 const random = () => poseidon2([Math.floor(Math.random() * 2 ** 40), 0])
 
 // Given a a merkle proof (elements and indexes) and a leaf, calculates the root
 function calculateRoot(element: BigInt, proofElements: BigNumber[], proofIndexes: boolean[]) {
-    var hash = element
-    for (let i = 0; i < proofElements.length; i++) {
+    let hash = element
+    for (let i = 0; i < proofElements.length; i += 1) {
         const proofElement = proofElements[i]
         const proofIndex = proofIndexes[i]
         if (proofIndex) {
@@ -316,6 +317,7 @@ describe("LazyIMT", () => {
             }
 
             // For each depth
+            // eslint-disable-next-line guard-for-in
             for (const depth in tests) {
                 // For each amount of leafs
                 for (const numLeaf of tests[depth]) {

--- a/packages/imt.sol/test/LazyIMT.ts
+++ b/packages/imt.sol/test/LazyIMT.ts
@@ -291,16 +291,16 @@ describe("LazyIMT", () => {
     })
 
     describe("# merkleProof", () => {
-        // Given a a merkle proof (elements and indexes) and a leaf, calculates the root
+        // Given a a merkle proof (elements and indices) and a leaf, calculates the root
         function calculateRoot(leafIndex: number, leaf: BigNumber, proofElements: BigNumber[]) {
             let hash = leaf
-            const proofIndexes = []
+            const proofIndices = []
             for (let x = 0; x < proofElements.length; x += 1) {
-                proofIndexes.push((leafIndex >> x) & 1)
+                proofIndices.push((leafIndex >> x) & 1)
             }
             for (let i = 0; i < proofElements.length; i += 1) {
                 const proofElement = proofElements[i]
-                const proofIndex = proofIndexes[i]
+                const proofIndex = proofIndices[i]
                 if (proofIndex) {
                     hash = poseidon2([proofElement.toString(), hash.toString()])
                 } else {
@@ -350,9 +350,10 @@ describe("LazyIMT", () => {
                         // If they match, proof is valid
                         await expect(calculatedRoot).to.be.equal(staticRoot)
                     }
+
+                    // Done with test, revert the tree state
+                    await network.provider.request({ method: "evm_revert", params: [snapshoot] })
                 }
-                // Done with test, revert the tree state
-                await network.provider.request({ method: "evm_revert", params: [snapshoot] })
             }
         }).timeout(5 * 60 * 1000)
     })

--- a/packages/imt.sol/test/LazyIMT.ts
+++ b/packages/imt.sol/test/LazyIMT.ts
@@ -320,14 +320,14 @@ describe("LazyIMT", () => {
                 20: [9, 14, 15, 16, 18, 26, 27, 28, 40, 128, 129]
             }
 
-            // Freeze the state
-            const snapshoot = await network.provider.request({ method: "evm_snapshot", params: [] })
-
             // For each depth
             // eslint-disable-next-line guard-for-in
             for (const depth in tests) {
                 // For each amount of leafs
                 for (const numLeaf of tests[depth]) {
+                    // Freeze the state
+                    const snapshoot = await network.provider.request({ method: "evm_snapshot", params: [] })
+
                     // Create the tree
                     await lazyIMTTest.init(depth)
                     const elements = []

--- a/packages/imt.sol/test/LazyIMT.ts
+++ b/packages/imt.sol/test/LazyIMT.ts
@@ -2,9 +2,29 @@ import { expect } from "chai"
 import { run } from "hardhat"
 import { poseidon2 } from "poseidon-lite"
 import { IMT } from "@zk-kit/imt"
+import type { BigNumber } from "ethers";
 import { LazyIMT, LazyIMTTest } from "../typechain-types"
-
 const random = () => poseidon2([Math.floor(Math.random() * 2 ** 40), 0])
+
+// Given a a merkle proof (elements and indexes) and a leaf, calculates the root
+function calculateRoot(
+    element: BigInt,
+    proofElements: BigNumber[],
+    proofIndexes: boolean[]) {
+
+    var hash = element;
+    for (let i = 0; i < proofElements.length; i++) {
+        const proofElement = proofElements[i];
+        const proofIndex = proofIndexes[i];
+        if (proofIndex) {
+            hash = poseidon2([proofElement.toString(), hash.toString()])
+        }
+        else {
+            hash = poseidon2([hash.toString(), proofElement.toString()])
+        }
+    }
+    return hash
+}
 
 describe("LazyIMT", () => {
     const SNARK_SCALAR_FIELD = BigInt("21888242871839275222246405745257275088548364400416034343698204186575808495617")
@@ -287,6 +307,48 @@ describe("LazyIMT", () => {
                 }
             }
         })
+    })
+
+    describe("# merkleProof", () => {
+        it("Should produce valid Merke proofs for different trees", async () => {
+            // Test different depths (key) and leafs (values)
+            const tests: { [key: number]: number[] } = {
+                1: [1],
+                2: [1, 2],
+                5: [6, 7, 8, 15, 16],
+                7: [7, 127],
+                20: [9, 14, 15, 16, 18, 26, 27, 28, 40, 128, 129]
+            };
+
+            // For each depth
+            for (const depth in tests) {
+
+                // For each amount of leafs
+                for (const numLeaf of tests[depth]) {
+
+                    // Create the tree
+                    await lazyIMTTest.init(depth)
+                    for (let x = 0; x < numLeaf; x += 1) {
+                        await lazyIMTTest.insert(x)
+                    }
+
+                    // Get proofs for every leafs and verify against the root
+                    for (let leafIndex = 0; leafIndex < numLeaf; leafIndex += 1) {
+                        const proofElements = await lazyIMTTest.merkleProofElements(leafIndex, depth)
+                        const proofIndexes = await lazyIMTTest.merkleProofIndexes(leafIndex, depth)
+
+                        // Calculate the root we arrive at with the proof we got
+                        const calculatedRoot = calculateRoot(BigInt(leafIndex), proofElements, proofIndexes)
+
+                        // Get the root from the contract
+                        const staticRoot = await lazyIMTTest.staticRoot(depth)
+
+                        // If they match, proof is valid
+                        await expect(calculatedRoot).to.be.equal(staticRoot)
+                    }
+                }
+            }
+        }).timeout(5 * 60 * 1000);
     })
 
     it("Should fail to generate out of range static root", async () => {

--- a/packages/imt.sol/test/LazyIMT.ts
+++ b/packages/imt.sol/test/LazyIMT.ts
@@ -2,24 +2,19 @@ import { expect } from "chai"
 import { run } from "hardhat"
 import { poseidon2 } from "poseidon-lite"
 import { IMT } from "@zk-kit/imt"
-import type { BigNumber } from "ethers";
+import type { BigNumber } from "ethers"
 import { LazyIMT, LazyIMTTest } from "../typechain-types"
 const random = () => poseidon2([Math.floor(Math.random() * 2 ** 40), 0])
 
 // Given a a merkle proof (elements and indexes) and a leaf, calculates the root
-function calculateRoot(
-    element: BigInt,
-    proofElements: BigNumber[],
-    proofIndexes: boolean[]) {
-
-    var hash = element;
+function calculateRoot(element: BigInt, proofElements: BigNumber[], proofIndexes: boolean[]) {
+    var hash = element
     for (let i = 0; i < proofElements.length; i++) {
-        const proofElement = proofElements[i];
-        const proofIndex = proofIndexes[i];
+        const proofElement = proofElements[i]
+        const proofIndex = proofIndexes[i]
         if (proofIndex) {
             hash = poseidon2([proofElement.toString(), hash.toString()])
-        }
-        else {
+        } else {
             hash = poseidon2([hash.toString(), proofElement.toString()])
         }
     }
@@ -318,14 +313,12 @@ describe("LazyIMT", () => {
                 5: [6, 7, 8, 15, 16],
                 7: [7, 127],
                 20: [9, 14, 15, 16, 18, 26, 27, 28, 40, 128, 129]
-            };
+            }
 
             // For each depth
             for (const depth in tests) {
-
                 // For each amount of leafs
                 for (const numLeaf of tests[depth]) {
-
                     // Create the tree
                     await lazyIMTTest.init(depth)
                     for (let x = 0; x < numLeaf; x += 1) {
@@ -348,7 +341,7 @@ describe("LazyIMT", () => {
                     }
                 }
             }
-        }).timeout(5 * 60 * 1000);
+        }).timeout(5 * 60 * 1000)
     })
 
     it("Should fail to generate out of range static root", async () => {


### PR DESCRIPTION
## Description

This PR adds a function to the `LazyIMT` contract, `_merkleProofElements`, which returns the Merkle proof of any leaf `index` in the tree. The `depth` is configurable, which allows to get the proofs of any subtree.

Closes https://github.com/privacy-scaling-explorations/zk-kit/issues/123
