### PR TITLE
feat: add safe comparators templates

### DIFF
--- a/packages/circuits/circom/circuits.json
+++ b/packages/circuits/circom/circuits.json
@@ -35,5 +35,29 @@
         "template": "Ecdh",
         "pubs": ["publicKey"],
         "params": []
+    },
+    "safe-less-than": {
+        "file": "safe-comparators",
+        "template": "SafeLessThan",
+        "pubs": ["in"],
+        "params": [252]
+    },
+    "safe-less-eq-than": {
+        "file": "safe-comparators",
+        "template": "SafeLessEqThan",
+        "pubs": ["in"],
+        "params": [252]
+    },
+    "safe-greater-than": {
+        "file": "safe-comparators",
+        "template": "SafeGreaterThan",
+        "pubs": ["in"],
+        "params": [252]
+    },
+    "safe-greater-eq-than": {
+        "file": "safe-comparators",
+        "template": "SafeGreaterEqThan",
+        "pubs": ["in"],
+        "params": [252]
     }
 }

--- a/packages/circuits/circom/safe-comparators.circom
+++ b/packages/circuits/circom/safe-comparators.circom
@@ -1,0 +1,56 @@
+pragma circom 2.0.0;
+
+include "./bitify.circom";
+
+// Template for safely comparing if one input is less than another,
+// ensuring inputs are within a specified bit-length.
+template SafeLessThan(n) {
+    // Ensure the bit-length does not exceed 252 bits.
+    assert(n <= 252);
+
+    signal input in[2];
+    signal output out;
+
+    // Convert both inputs to their bit representations to ensure 
+    // they fit within 'n' bits.
+    var n2b1[n];
+    n2b1 = Num2Bits(n)(in[0]);
+
+    var n2b2[n];
+    n2b2 = Num2Bits(n)(in[1]);
+
+    // Additional conversion to handle arithmetic operation and capture the comparison result.
+    var n2b[n+1];
+    n2b = Num2Bits(n + 1)(in[0] + (1<<n) - in[1]);
+
+    // Determine if in[0] is less than in[1] based on the most significant bit.
+    out <== 1 - n2b[n];
+}
+
+// Template to check if one input is less than or equal to another.
+template SafeLessEqThan(n) {
+    signal input in[2];
+    signal output out;
+
+    // Use SafeLessThan to determine if in[0] is less than in[1] + 1.
+    out <== SafeLessThan(n)([in[0], in[1] + 1]);
+}
+
+// Template for safely comparing if one input is greater than another.
+template SafeGreaterThan(n) {
+    signal input in[2]; // Two inputs to compare.
+    signal output out; // Output signal indicating comparison result.
+
+    // Invert the inputs for SafeLessThan to check if in[1] is less than in[0].
+    out <== SafeLessThan(n)([in[1], in[0]]);
+}
+
+// Template to check if one input is greater than or equal to another.
+template SafeGreaterEqThan(n) {
+    signal input in[2]; // Two inputs to compare.
+    signal output out; // Output signal indicating comparison result.
+
+    // Invert the inputs and adjust for equality in SafeLessThan to 
+    // check if in[1] is less than or equal to in[0].
+    out <== SafeLessThan(n)([in[1], in[0] + 1]);
+}

--- a/packages/circuits/circom/safe-comparators.circom
+++ b/packages/circuits/circom/safe-comparators.circom
@@ -38,8 +38,10 @@ template SafeLessEqThan(n) {
 
 // Template for safely comparing if one input is greater than another.
 template SafeGreaterThan(n) {
-    signal input in[2]; // Two inputs to compare.
-    signal output out; // Output signal indicating comparison result.
+    // Two inputs to compare.
+    signal input in[2];
+    // Output signal indicating comparison result.
+    signal output out;
 
     // Invert the inputs for SafeLessThan to check if in[1] is less than in[0].
     out <== SafeLessThan(n)([in[1], in[0]]);
@@ -47,8 +49,10 @@ template SafeGreaterThan(n) {
 
 // Template to check if one input is greater than or equal to another.
 template SafeGreaterEqThan(n) {
-    signal input in[2]; // Two inputs to compare.
-    signal output out; // Output signal indicating comparison result.
+    // Two inputs to compare.
+    signal input in[2];
+    // Output signal indicating comparison result.
+    signal output out;
 
     // Invert the inputs and adjust for equality in SafeLessThan to 
     // check if in[1] is less than or equal to in[0].

--- a/packages/circuits/tests/safe-comparators.test.ts
+++ b/packages/circuits/tests/safe-comparators.test.ts
@@ -1,0 +1,116 @@
+import { WitnessTester } from "circomkit"
+import { circomkit } from "./common"
+
+describe("safe-comparators", () => {
+    describe("SafeLessThan", () => {
+        let circuit: WitnessTester<["in"], ["out"]>
+
+        // Test values
+        const inValues = [5, 10] // in[0] < in[1], expecting 'out' to be 1.
+        const expectedOut = 1 // Since 5 is less than 10.
+
+        const INPUT = {
+            in: inValues
+        }
+
+        const OUTPUT = {
+            out: expectedOut
+        }
+
+        before(async () => {
+            circuit = await circomkit.WitnessTester("SafeLessThan", {
+                file: "safe-comparators",
+                template: "SafeLessThan",
+                params: [252] // Assuming we're working within 252-bit numbers.
+            })
+        })
+
+        it("Should correctly compare two numbers", async () => {
+            await circuit.expectPass(INPUT, OUTPUT)
+        })
+    })
+
+    describe("SafeLessEqThan", () => {
+        let circuit: WitnessTester<["in"], ["out"]>
+
+        // Test values
+        const inValues = [5, 5] // in[0] === in[1], expecting 'out' to be 1.
+        const expectedOut = 1 // Since 5 is equal to 5.
+
+        const INPUT = {
+            in: inValues
+        }
+
+        const OUTPUT = {
+            out: expectedOut
+        }
+
+        before(async () => {
+            circuit = await circomkit.WitnessTester("SafeLessEqThan", {
+                file: "safe-comparators",
+                template: "SafeLessEqThan",
+                params: [252] // Assuming we're working within 252-bit numbers.
+            })
+        })
+
+        it("Should correctly compare two numbers", async () => {
+            await circuit.expectPass(INPUT, OUTPUT)
+        })
+    })
+
+    describe("SafeGreaterThan", () => {
+        let circuit: WitnessTester<["in"], ["out"]>
+
+        // Test values
+        const inValues = [10, 5] // in[0] > in[1], expecting 'out' to be 1.
+        const expectedOut = 1 // Since 10 is greater than 5.
+
+        const INPUT = {
+            in: inValues
+        }
+
+        const OUTPUT = {
+            out: expectedOut
+        }
+
+        before(async () => {
+            circuit = await circomkit.WitnessTester("SafeGreaterThan", {
+                file: "safe-comparators",
+                template: "SafeGreaterThan",
+                params: [252] // Assuming we're working within 252-bit numbers.
+            })
+        })
+
+        it("Should correctly compare two numbers", async () => {
+            await circuit.expectPass(INPUT, OUTPUT)
+        })
+    })
+
+    describe("SafeGreaterEqThan", () => {
+        let circuit: WitnessTester<["in"], ["out"]>
+
+        // Test values
+        const inValues = [5, 5] // in[0] === in[1], expecting 'out' to be 1.
+        const expectedOut = 1 // Since 5 is equal to 5.
+
+        const INPUT = {
+            in: inValues
+        }
+
+        const OUTPUT = {
+            out: expectedOut
+        }
+
+        before(async () => {
+            circuit = await circomkit.WitnessTester("SafeGreaterEqThan", {
+                file: "safe-comparators",
+                template: "SafeGreaterEqThan",
+                params: [252] // Assuming we're working within 252-bit numbers.
+            })
+        })
+
+        it("Should correctly compare two numbers", async () => {
+            await circuit.expectPass(INPUT, OUTPUT)
+        })
+    })
+})

--- a/packages/circuits/tests/safe-comparators.test.ts
+++ b/packages/circuits/tests/safe-comparators.test.ts
@@ -5,27 +5,69 @@ describe("safe-comparators", () => {
     describe("SafeLessThan", () => {
         let circuit: WitnessTester<["in"], ["out"]>
 
-        // Test values
-        const inValues = [5, 10] // in[0] < in[1], expecting 'out' to be 1.
-        const expectedOut = 1 // Since 5 is less than 10.
+        it("Should correctly compare two numbers [x, x]", async () => {
+            // Test values
+            const inValues = [5, 5] // in[0] === in[1], expecting 'out' to be 0.
+            const expectedOut = 0 // Since 5 is equal to 5.
 
-        const INPUT = {
-            in: inValues
-        }
+            const INPUT = {
+                in: inValues
+            }
 
-        const OUTPUT = {
-            out: expectedOut
-        }
+            const OUTPUT = {
+                out: expectedOut
+            }
 
-        before(async () => {
             circuit = await circomkit.WitnessTester("SafeLessThan", {
                 file: "safe-comparators",
                 template: "SafeLessThan",
                 params: [252] // Assuming we're working within 252-bit numbers.
             })
+
+            await circuit.expectPass(INPUT, OUTPUT)
         })
 
-        it("Should correctly compare two numbers", async () => {
+        it("Should correctly compare two numbers [x-1, x]", async () => {
+            // Test values
+            const inValues = [5, 6] // in[0] < in[1], expecting 'out' to be 1.
+            const expectedOut = 1 // Since 5 is less than 6.
+
+            const INPUT = {
+                in: inValues
+            }
+
+            const OUTPUT = {
+                out: expectedOut
+            }
+
+            circuit = await circomkit.WitnessTester("SafeLessThan", {
+                file: "safe-comparators",
+                template: "SafeLessThan",
+                params: [252] // Assuming we're working within 252-bit numbers.
+            })
+
+            await circuit.expectPass(INPUT, OUTPUT)
+        })
+
+        it("Should correctly compare two numbers [x, x-1]", async () => {
+            // Test values
+            const inValues = [6, 5] // in[0] > in[1], expecting 'out' to be 0.
+            const expectedOut = 0 // Since 6 is greater than 5.
+
+            const INPUT = {
+                in: inValues
+            }
+
+            const OUTPUT = {
+                out: expectedOut
+            }
+
+            circuit = await circomkit.WitnessTester("SafeLessThan", {
+                file: "safe-comparators",
+                template: "SafeLessThan",
+                params: [252] // Assuming we're working within 252-bit numbers.
+            })
+
             await circuit.expectPass(INPUT, OUTPUT)
         })
     })
@@ -33,27 +75,69 @@ describe("safe-comparators", () => {
     describe("SafeLessEqThan", () => {
         let circuit: WitnessTester<["in"], ["out"]>
 
-        // Test values
-        const inValues = [5, 5] // in[0] === in[1], expecting 'out' to be 1.
-        const expectedOut = 1 // Since 5 is equal to 5.
+        it("Should correctly compare two numbers [x, x]", async () => {
+            // Test values
+            const inValues = [5, 5] // in[0] === in[1], expecting 'out' to be 1.
+            const expectedOut = 1 // Since 5 is equal to 5.
 
-        const INPUT = {
-            in: inValues
-        }
+            const INPUT = {
+                in: inValues
+            }
 
-        const OUTPUT = {
-            out: expectedOut
-        }
+            const OUTPUT = {
+                out: expectedOut
+            }
 
-        before(async () => {
             circuit = await circomkit.WitnessTester("SafeLessEqThan", {
                 file: "safe-comparators",
                 template: "SafeLessEqThan",
                 params: [252] // Assuming we're working within 252-bit numbers.
             })
+
+            await circuit.expectPass(INPUT, OUTPUT)
         })
 
-        it("Should correctly compare two numbers", async () => {
+        it("Should correctly compare two numbers [x-1, x]", async () => {
+            // Test values
+            const inValues = [5, 6] // in[0] < in[1], expecting 'out' to be 1.
+            const expectedOut = 1 // Since 5 is less than 6.
+
+            const INPUT = {
+                in: inValues
+            }
+
+            const OUTPUT = {
+                out: expectedOut
+            }
+
+            circuit = await circomkit.WitnessTester("SafeLessEqThan", {
+                file: "safe-comparators",
+                template: "SafeLessEqThan",
+                params: [252] // Assuming we're working within 252-bit numbers.
+            })
+
+            await circuit.expectPass(INPUT, OUTPUT)
+        })
+
+        it("Should correctly compare two numbers [x, x-1]", async () => {
+            // Test values
+            const inValues = [6, 5] // in[0] > in[1], expecting 'out' to be 0.
+            const expectedOut = 0 // Since 6 is greater than 5.
+
+            const INPUT = {
+                in: inValues
+            }
+
+            const OUTPUT = {
+                out: expectedOut
+            }
+
+            circuit = await circomkit.WitnessTester("SafeLessEqThan", {
+                file: "safe-comparators",
+                template: "SafeLessEqThan",
+                params: [252] // Assuming we're working within 252-bit numbers.
+            })
+
             await circuit.expectPass(INPUT, OUTPUT)
         })
     })
@@ -61,27 +145,69 @@ describe("safe-comparators", () => {
     describe("SafeGreaterThan", () => {
         let circuit: WitnessTester<["in"], ["out"]>
 
-        // Test values
-        const inValues = [10, 5] // in[0] > in[1], expecting 'out' to be 1.
-        const expectedOut = 1 // Since 10 is greater than 5.
+        it("Should correctly compare two numbers [x, x]", async () => {
+            // Test values
+            const inValues = [5, 5] // in[0] === in[1], expecting 'out' to be 0.
+            const expectedOut = 0 // Since 5 is equal to 5.
 
-        const INPUT = {
-            in: inValues
-        }
+            const INPUT = {
+                in: inValues
+            }
 
-        const OUTPUT = {
-            out: expectedOut
-        }
+            const OUTPUT = {
+                out: expectedOut
+            }
 
-        before(async () => {
             circuit = await circomkit.WitnessTester("SafeGreaterThan", {
                 file: "safe-comparators",
                 template: "SafeGreaterThan",
                 params: [252] // Assuming we're working within 252-bit numbers.
             })
+
+            await circuit.expectPass(INPUT, OUTPUT)
         })
 
-        it("Should correctly compare two numbers", async () => {
+        it("Should correctly compare two numbers [x-1, x]", async () => {
+            // Test values
+            const inValues = [5, 6] // in[0] < in[1], expecting 'out' to be 0.
+            const expectedOut = 0 // Since 5 is less than 6.
+
+            const INPUT = {
+                in: inValues
+            }
+
+            const OUTPUT = {
+                out: expectedOut
+            }
+
+            circuit = await circomkit.WitnessTester("SafeGreaterThan", {
+                file: "safe-comparators",
+                template: "SafeGreaterThan",
+                params: [252] // Assuming we're working within 252-bit numbers.
+            })
+
+            await circuit.expectPass(INPUT, OUTPUT)
+        })
+
+        it("Should correctly compare two numbers [x, x-1]", async () => {
+            // Test values
+            const inValues = [6, 5] // in[0] > in[1], expecting 'out' to be 1.
+            const expectedOut = 1 // Since 6 is greater than 5.
+
+            const INPUT = {
+                in: inValues
+            }
+
+            const OUTPUT = {
+                out: expectedOut
+            }
+
+            circuit = await circomkit.WitnessTester("SafeGreaterThan", {
+                file: "safe-comparators",
+                template: "SafeGreaterThan",
+                params: [252] // Assuming we're working within 252-bit numbers.
+            })
+
             await circuit.expectPass(INPUT, OUTPUT)
         })
     })
@@ -89,27 +215,69 @@ describe("safe-comparators", () => {
     describe("SafeGreaterEqThan", () => {
         let circuit: WitnessTester<["in"], ["out"]>
 
-        // Test values
-        const inValues = [5, 5] // in[0] === in[1], expecting 'out' to be 1.
-        const expectedOut = 1 // Since 5 is equal to 5.
+        it("Should correctly compare two numbers [x, x]", async () => {
+            // Test values
+            const inValues = [5, 5] // in[0] === in[1], expecting 'out' to be 1.
+            const expectedOut = 1 // Since 5 is equal to 5.
 
-        const INPUT = {
-            in: inValues
-        }
+            const INPUT = {
+                in: inValues
+            }
 
-        const OUTPUT = {
-            out: expectedOut
-        }
+            const OUTPUT = {
+                out: expectedOut
+            }
 
-        before(async () => {
             circuit = await circomkit.WitnessTester("SafeGreaterEqThan", {
                 file: "safe-comparators",
                 template: "SafeGreaterEqThan",
                 params: [252] // Assuming we're working within 252-bit numbers.
             })
+
+            await circuit.expectPass(INPUT, OUTPUT)
         })
 
-        it("Should correctly compare two numbers", async () => {
+        it("Should correctly compare two numbers [x-1, x]", async () => {
+            // Test values
+            const inValues = [5, 6] // in[0] < in[1], expecting 'out' to be 0.
+            const expectedOut = 0 // Since 5 is less than 6.
+
+            const INPUT = {
+                in: inValues
+            }
+
+            const OUTPUT = {
+                out: expectedOut
+            }
+
+            circuit = await circomkit.WitnessTester("SafeGreaterEqThan", {
+                file: "safe-comparators",
+                template: "SafeGreaterEqThan",
+                params: [252] // Assuming we're working within 252-bit numbers.
+            })
+
+            await circuit.expectPass(INPUT, OUTPUT)
+        })
+
+        it("Should correctly compare two numbers [x, x-1]", async () => {
+            // Test values
+            const inValues = [6, 5] // in[0] > in[1], expecting 'out' to be 1.
+            const expectedOut = 1 // Since 6 is greater than 5.
+
+            const INPUT = {
+                in: inValues
+            }
+
+            const OUTPUT = {
+                out: expectedOut
+            }
+
+            circuit = await circomkit.WitnessTester("SafeGreaterEqThan", {
+                file: "safe-comparators",
+                template: "SafeGreaterEqThan",
+                params: [252] // Assuming we're working within 252-bit numbers.
+            })
+
             await circuit.expectPass(INPUT, OUTPUT)
         })
     })


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description
This PR adds the safe comparators (`SafeLessThan`, `SafeLessEqThan`, `SafeGreaterThan`, `SafeGreaterEqThan`) circom templates. These circuits are pretty much similar to the [circomlib](https://github.com/iden3/circomlib/blob/cff5ab6288b55ef23602221694a6a38a0239dcc0/circuits/comparators.circom) ones but they add a conversion of the inputs to compare to their bit representations to ensure they fit within 'n' bits (implicit range check).

Compared to the original version of MACI, Anonymous Components were used, resulting in DX improvement and small optimisation.

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

## Related Issue(s)
see #131 

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
<!-- Feel free to remove this section if you will not use it. -->

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have run `yarn prettier` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] Any dependent changes have been merged and published in downstream modules
