### PR TITLE
Replace `groth16` dependency with `snarkjs` in `eddsa-proof` and `poseidon-proof`

### DIFF
--- a/packages/eddsa-proof/package.json
+++ b/packages/eddsa-proof/package.json
@@ -42,6 +42,7 @@
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-typescript": "^11.1.6",
         "@types/download": "^8.0.5",
+        "@types/snarkjs": "^0",
         "@types/tmp": "^0.2.6",
         "poseidon-lite": "^0.2.0",
         "rimraf": "^5.0.5",
@@ -53,8 +54,8 @@
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/keccak256": "^5.7.0",
         "@zk-kit/eddsa-poseidon": "0.5.1",
-        "@zk-kit/groth16": "0.5.0",
         "download": "^8.0.0",
+        "snarkjs": "^0.7.3",
         "tmp": "^0.2.1"
     }
 }

--- a/packages/eddsa-proof/src/generate.ts
+++ b/packages/eddsa-proof/src/generate.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from "@ethersproject/bignumber"
 import { BytesLike, Hexable } from "@ethersproject/bytes"
-import { NumericString, prove } from "@zk-kit/groth16"
 import { deriveSecretScalar } from "@zk-kit/eddsa-poseidon"
+import { NumericString, groth16 } from "snarkjs"
 import getSnarkArtifacts from "./get-snark-artifacts.node"
 import hash from "./hash"
 import packProof from "./pack-proof"
@@ -35,7 +35,7 @@ export default async function generate(
 
     const secretScalar = deriveSecretScalar(privateKey)
 
-    const { proof, publicSignals } = await prove(
+    const { proof, publicSignals } = await groth16.fullProve(
         {
             secret: secretScalar,
             scope: hash(scope)

--- a/packages/eddsa-proof/src/hash.ts
+++ b/packages/eddsa-proof/src/hash.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from "@ethersproject/bignumber"
 import { BytesLike, Hexable, zeroPad } from "@ethersproject/bytes"
 import { keccak256 } from "@ethersproject/keccak256"
-import { NumericString } from "@zk-kit/groth16"
+import { NumericString } from "snarkjs"
 
 /**
  * Creates a keccak256 hash of a message compatible with the SNARK scalar modulus.

--- a/packages/eddsa-proof/src/types/index.ts
+++ b/packages/eddsa-proof/src/types/index.ts
@@ -1,4 +1,4 @@
-import { NumericString } from "@zk-kit/groth16"
+import { NumericString } from "snarkjs"
 
 export type SnarkArtifacts = {
     wasmFilePath: string

--- a/packages/eddsa-proof/src/unpack-proof.ts
+++ b/packages/eddsa-proof/src/unpack-proof.ts
@@ -1,4 +1,4 @@
-import { Groth16Proof } from "@zk-kit/groth16"
+import { Groth16Proof } from "snarkjs"
 import { PackedProof } from "./types"
 
 /**

--- a/packages/eddsa-proof/src/verify.ts
+++ b/packages/eddsa-proof/src/verify.ts
@@ -1,8 +1,8 @@
-import { verify as _verify } from "@zk-kit/groth16"
+import { groth16 } from "snarkjs"
+import hash from "./hash"
 import { EddsaProof } from "./types"
 import unpackProof from "./unpack-proof"
 import verificationKey from "./verification-key.json"
-import hash from "./hash"
 
 /**
  * Verifies that a Eddsa proof is valid.
@@ -10,8 +10,5 @@ import hash from "./hash"
  * @returns True if the proof is valid, false otherwise.
  */
 export default function verify({ commitment, scope, proof }: EddsaProof): Promise<boolean> {
-    return _verify(verificationKey, {
-        publicSignals: [commitment, hash(scope)],
-        proof: unpackProof(proof)
-    })
+    return groth16.verify(verificationKey, [commitment, hash(scope)], unpackProof(proof))
 }

--- a/packages/poseidon-proof/package.json
+++ b/packages/poseidon-proof/package.json
@@ -42,6 +42,7 @@
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-typescript": "^11.1.6",
         "@types/download": "^8.0.5",
+        "@types/snarkjs": "^0",
         "@types/tmp": "^0.2.6",
         "poseidon-lite": "^0.2.0",
         "rimraf": "^5.0.5",
@@ -52,8 +53,8 @@
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/keccak256": "^5.7.0",
-        "@zk-kit/groth16": "0.4.0",
         "download": "^8.0.0",
+        "snarkjs": "^0.7.3",
         "tmp": "^0.2.1"
     }
 }

--- a/packages/poseidon-proof/src/generate.ts
+++ b/packages/poseidon-proof/src/generate.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from "@ethersproject/bignumber"
 import { BytesLike, Hexable } from "@ethersproject/bytes"
-import { NumericString, prove } from "@zk-kit/groth16"
+import { NumericString, groth16 } from "snarkjs"
 import getSnarkArtifacts from "./get-snark-artifacts.node"
 import hash from "./hash"
 import packProof from "./pack-proof"
@@ -32,7 +32,7 @@ export default async function generate(
         snarkArtifacts = await getSnarkArtifacts(preimages.length)
     }
 
-    const { proof, publicSignals } = await prove(
+    const { proof, publicSignals } = await groth16.fullProve(
         {
             preimages: preimages.map((preimage) => hash(preimage)),
             scope: hash(scope)

--- a/packages/poseidon-proof/src/hash.ts
+++ b/packages/poseidon-proof/src/hash.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from "@ethersproject/bignumber"
 import { BytesLike, Hexable, zeroPad } from "@ethersproject/bytes"
 import { keccak256 } from "@ethersproject/keccak256"
-import { NumericString } from "@zk-kit/groth16"
+import { NumericString } from "snarkjs"
 
 /**
  * Creates a keccak256 hash of a message compatible with the SNARK scalar modulus.

--- a/packages/poseidon-proof/src/pack-proof.ts
+++ b/packages/poseidon-proof/src/pack-proof.ts
@@ -1,4 +1,4 @@
-import { Groth16Proof } from "@zk-kit/groth16"
+import { Groth16Proof } from "snarkjs"
 import { PackedProof } from "./types"
 
 /**

--- a/packages/poseidon-proof/src/types/index.ts
+++ b/packages/poseidon-proof/src/types/index.ts
@@ -1,4 +1,4 @@
-import { NumericString } from "@zk-kit/groth16"
+import { NumericString } from "snarkjs"
 
 export type SnarkArtifacts = {
     wasmFilePath: string

--- a/packages/poseidon-proof/src/unpack-proof.ts
+++ b/packages/poseidon-proof/src/unpack-proof.ts
@@ -1,4 +1,4 @@
-import { Groth16Proof } from "@zk-kit/groth16"
+import { Groth16Proof } from "snarkjs"
 import { PackedProof } from "./types"
 
 /**

--- a/packages/poseidon-proof/src/verify.ts
+++ b/packages/poseidon-proof/src/verify.ts
@@ -1,4 +1,4 @@
-import { verify as _verify } from "@zk-kit/groth16"
+import { groth16 } from "snarkjs"
 import hash from "./hash"
 import { PoseidonProof } from "./types"
 import unpackProof from "./unpack-proof"
@@ -19,8 +19,5 @@ export default function verify(
         IC: verificationKeys.IC[numberOfInputs - 1]
     }
 
-    return _verify(verificationKey, {
-        publicSignals: [digest, nullifier, hash(scope)],
-        proof: unpackProof(proof)
-    })
+    return groth16.verify(verificationKey, [digest, nullifier, hash(scope)], unpackProof(proof))
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3215,6 +3215,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/snarkjs@npm:^0":
+  version: 0.7.8
+  resolution: "@types/snarkjs@npm:0.7.8"
+  checksum: 10/26b2f8b8329ca9e6a0f027990262504faeae4154fbd60f18218f94623d26e2cf5abbad7048b1a0c859e19f7a7848e28f40d212a2feb4f6ff975cad23b8bd55c4
+  languageName: node
+  linkType: hard
+
 "@types/stack-utils@npm:^2.0.0":
   version: 2.0.3
   resolution: "@types/stack-utils@npm:2.0.3"
@@ -3543,29 +3550,20 @@ __metadata:
     "@rollup/plugin-json": "npm:^6.1.0"
     "@rollup/plugin-typescript": "npm:^11.1.6"
     "@types/download": "npm:^8.0.5"
+    "@types/snarkjs": "npm:^0"
     "@types/tmp": "npm:^0.2.6"
     "@zk-kit/eddsa-poseidon": "npm:0.5.1"
-    "@zk-kit/groth16": "npm:0.5.0"
     download: "npm:^8.0.0"
     poseidon-lite: "npm:^0.2.0"
     rimraf: "npm:^5.0.5"
     rollup: "npm:^4.12.0"
     rollup-plugin-cleanup: "npm:^3.2.1"
+    snarkjs: "npm:^0.7.3"
     tmp: "npm:^0.2.1"
   languageName: unknown
   linkType: soft
 
-"@zk-kit/groth16@npm:0.4.0":
-  version: 0.4.0
-  resolution: "@zk-kit/groth16@npm:0.4.0"
-  dependencies:
-    circom_runtime: "npm:0.1.24"
-    ffjavascript: "npm:0.2.60"
-  checksum: 10/80d6b1a67e24cc5105464799a3e105fb4be7b825daccf185171f86b4a1d106aef775d4aafd221e92679147c8d783fe66383cf545c993c96645f1a0ffefc8ccb9
-  languageName: node
-  linkType: hard
-
-"@zk-kit/groth16@npm:0.5.0, @zk-kit/groth16@workspace:packages/groth16":
+"@zk-kit/groth16@workspace:packages/groth16":
   version: 0.0.0-use.local
   resolution: "@zk-kit/groth16@workspace:packages/groth16"
   dependencies:
@@ -3656,13 +3654,14 @@ __metadata:
     "@rollup/plugin-json": "npm:^6.1.0"
     "@rollup/plugin-typescript": "npm:^11.1.6"
     "@types/download": "npm:^8.0.5"
+    "@types/snarkjs": "npm:^0"
     "@types/tmp": "npm:^0.2.6"
-    "@zk-kit/groth16": "npm:0.4.0"
     download: "npm:^8.0.0"
     poseidon-lite: "npm:^0.2.0"
     rimraf: "npm:^5.0.5"
     rollup: "npm:^4.12.0"
     rollup-plugin-cleanup: "npm:^3.2.1"
+    snarkjs: "npm:^0.7.3"
     tmp: "npm:^0.2.1"
   languageName: unknown
   linkType: soft
@@ -15946,7 +15945,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"snarkjs@npm:^0.7.0":
+"snarkjs@npm:^0.7.0, snarkjs@npm:^0.7.3":
   version: 0.7.3
   resolution: "snarkjs@npm:0.7.3"
   dependencies:


### PR DESCRIPTION
## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

Closes #169

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have run `yarn prettier` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] Any dependent changes have been merged and published in downstream modules
