### PR TITLE
Add new utility functions to convert hex and buffers

### DIFF
--- a/packages/utils/src/conversions.ts
+++ b/packages/utils/src/conversions.ts
@@ -186,70 +186,24 @@ export function bigNumberishToBuffer(n: BigNumberish): Buffer {
 
 /**
  * Converts an hexadecimal string to a buffer. The hexadecimal string
- * should not start with '0x' or '0X'.
- * It uses a big-endian byte order.
+ * should not start with '0x' or '0X'. It keeps the bytes in the same order.
  * @param value The hexadecimal string to convert.
  * @returns The buffer representation of the hexadecimal string.
  */
-export function beHexadecimalToBuffer(value: string): Buffer {
+export function hexadecimalToBuffer(value: string): Buffer {
     requireHexadecimal(value, "value", false)
 
     return Buffer.from(value, "hex")
 }
 
 /**
- * Converts an hexadecimal string to a buffer. The hexadecimal string
- * should not start with '0x' or '0X'.
- * It uses a little-endian byte order.
- * @param value The hexadecimal string to convert.
- * @returns The buffer representation of the hexadecimal string.
- */
-export function leHexadecimalToBuffer(value: string): Buffer {
-    requireHexadecimal(value, "value", false)
-
-    return Buffer.from(value, "hex").reverse()
-}
-
-/**
- * Converts an hexadecimal string to a buffer. Alias for beHexadecimalToBuffer.
- * @param value The hexadecimal string to convert.
- * @returns The buffer representation of the hexadecimal string.
- */
-export function hexadecimalToBuffer(value: string): Buffer {
-    return beHexadecimalToBuffer(value)
-}
-
-/**
  * Converts a buffer to a hexadecimal string. It accepts 'Buffer' or 'Uint8Array'.
- * The hexadecimal string will not start with '0x' or '0X'.
- * It uses a big-endian byte order.
- * @param value The buffer to convert.
- * @returns The converted hexadecimal string.
- */
-export function beBufferToHexadecimal(value: Buffer | Uint8Array): string {
-    requireTypes(value, "value", ["Buffer", "Uint8Array"])
-
-    return Buffer.from(value).toString("hex")
-}
-
-/**
- * Converts a buffer to a hexadecimal string. It accepts 'Buffer' or 'Uint8Array'.
- * The hexadecimal string will not start with '0x' or '0X'.
- * It uses a little-endian byte order.
- * @param value The buffer to convert.
- * @returns The converted hexadecimal string.
- */
-export function leBufferToHexadecimal(value: Buffer | Uint8Array): string {
-    requireTypes(value, "value", ["Buffer", "Uint8Array"])
-
-    return Buffer.from(value).reverse().toString("hex")
-}
-
-/**
- * Converts a buffer to a hexadecimal string. Alias for beBufferToHexadecimal.
+ * The hexadecimal string will not start with '0x' or '0X'. It keeps the bytes in the same order.
  * @param value The buffer to convert.
  * @returns The converted hexadecimal string.
  */
 export function bufferToHexadecimal(value: Buffer | Uint8Array): string {
-    return beBufferToHexadecimal(value)
+    requireTypes(value, "value", ["Buffer", "Uint8Array"])
+
+    return Buffer.from(value).toString("hex")
 }

--- a/packages/utils/src/conversions.ts
+++ b/packages/utils/src/conversions.ts
@@ -12,7 +12,8 @@
  * the order of bytes is always big-endian.
  */
 
-import { isBigInt, isHexadecimal, isNumber, isStringifiedBigInt } from "./type-checks"
+import { requireHexadecimal, requireTypes } from "./error-handlers"
+import { isBigInt, isBuffer, isHexadecimal, isNumber, isStringifiedBigInt } from "./type-checks"
 import { BigNumber, BigNumberish } from "./types"
 
 /**
@@ -176,9 +177,79 @@ export function bigNumberishToBigInt(n: BigNumberish): bigint {
  * @returns The buffer representation of the BigNumberish value.
  */
 export function bigNumberishToBuffer(n: BigNumberish): Buffer {
-    if (n instanceof Buffer) {
-        return n
+    if (isBuffer(n)) {
+        return n as Buffer
     }
 
     return bigIntToBuffer(bigNumberishToBigInt(n))
+}
+
+/**
+ * Converts an hexadecimal string to a buffer. The hexadecimal string
+ * should not start with '0x' or '0X'.
+ * It uses a big-endian byte order.
+ * @param value The hexadecimal string to convert.
+ * @returns The buffer representation of the hexadecimal string.
+ */
+export function beHexadecimalToBuffer(value: string): Buffer {
+    requireHexadecimal(value, "value", false)
+
+    return Buffer.from(value, "hex")
+}
+
+/**
+ * Converts an hexadecimal string to a buffer. The hexadecimal string
+ * should not start with '0x' or '0X'.
+ * It uses a little-endian byte order.
+ * @param value The hexadecimal string to convert.
+ * @returns The buffer representation of the hexadecimal string.
+ */
+export function leHexadecimalToBuffer(value: string): Buffer {
+    requireHexadecimal(value, "value", false)
+
+    return Buffer.from(value, "hex").reverse()
+}
+
+/**
+ * Converts an hexadecimal string to a buffer. Alias for beHexadecimalToBuffer.
+ * @param value The hexadecimal string to convert.
+ * @returns The buffer representation of the hexadecimal string.
+ */
+export function hexadecimalToBuffer(value: string): Buffer {
+    return beHexadecimalToBuffer(value)
+}
+
+/**
+ * Converts a buffer to a hexadecimal string. It accepts 'Buffer' or 'Uint8Array'.
+ * The hexadecimal string will not start with '0x' or '0X'.
+ * It uses a big-endian byte order.
+ * @param value The buffer to convert.
+ * @returns The converted hexadecimal string.
+ */
+export function beBufferToHexadecimal(value: Buffer | Uint8Array): string {
+    requireTypes(value, "value", ["Buffer", "Uint8Array"])
+
+    return Buffer.from(value).toString("hex")
+}
+
+/**
+ * Converts a buffer to a hexadecimal string. It accepts 'Buffer' or 'Uint8Array'.
+ * The hexadecimal string will not start with '0x' or '0X'.
+ * It uses a little-endian byte order.
+ * @param value The buffer to convert.
+ * @returns The converted hexadecimal string.
+ */
+export function leBufferToHexadecimal(value: Buffer | Uint8Array): string {
+    requireTypes(value, "value", ["Buffer", "Uint8Array"])
+
+    return Buffer.from(value).reverse().toString("hex")
+}
+
+/**
+ * Converts a buffer to a hexadecimal string. Alias for beBufferToHexadecimal.
+ * @param value The buffer to convert.
+ * @returns The converted hexadecimal string.
+ */
+export function bufferToHexadecimal(value: Buffer | Uint8Array): string {
+    return beBufferToHexadecimal(value)
 }

--- a/packages/utils/src/error-handlers.ts
+++ b/packages/utils/src/error-handlers.ts
@@ -140,7 +140,7 @@ export function requireStringifiedBigInt(parameterValue: string, parameterName: 
 /**
  * @throws Throws a type error if the parameter value is not a hexadecimal string.
  * If 'prefix' is 'true', the string must start with '0x' or '0X' followed by one or more
- * hexadecimal digits (0-9, a-f, A-F), otherwise no prefix is needed. 'prefix' is optional and
+ * hexadecimal digits (0-9, a-f, A-F), otherwise no prefix is expected. 'prefix' is optional and
  * if its value it is not explicitly defined it will be set to 'true' by default.
  * @param parameterValue The parameter value.
  * @param parameterName The parameter name.

--- a/packages/utils/src/error-handlers.ts
+++ b/packages/utils/src/error-handlers.ts
@@ -139,8 +139,9 @@ export function requireStringifiedBigInt(parameterValue: string, parameterName: 
 
 /**
  * @throws Throws a type error if the parameter value is not a hexadecimal string.
- * If 'prefix' is not defined and set to 'false', the string must start with '0x' or '0X'
- * followed by one or more hexadecimal digits (0-9, a-f, A-F).
+ * If 'prefix' is 'true', the string must start with '0x' or '0X' followed by one or more
+ * hexadecimal digits (0-9, a-f, A-F), otherwise no prefix is needed. 'prefix' is optional and
+ * if its value it is not explicitly defined it will be set to 'true' by default.
  * @param parameterValue The parameter value.
  * @param parameterName The parameter name.
  * @param prefix A boolean to include or not a '0x' or '0X' prefix.

--- a/packages/utils/src/error-handlers.ts
+++ b/packages/utils/src/error-handlers.ts
@@ -13,6 +13,7 @@ import {
     isArray,
     isBigInt,
     isBigNumberish,
+    isBuffer,
     isDefined,
     isFunction,
     isHexadecimal,
@@ -92,6 +93,17 @@ export function requireUint8Array(parameterValue: Uint8Array, parameterName: str
 }
 
 /**
+ * @throws Throws a type error if the parameter value is not a Buffer.
+ * @param parameterValue The parameter value.
+ * @param parameterName The parameter name.
+ */
+export function requireBuffer(parameterValue: Buffer, parameterName: string) {
+    if (!isBuffer(parameterValue)) {
+        throw new TypeError(`Parameter '${parameterName}' is not a Buffer instance`)
+    }
+}
+
+/**
  * @throws Throws a type error if the parameter value is not an object.
  * Please, note that arrays are also objects in JavaScript.
  * @param parameterValue The parameter value.
@@ -127,11 +139,14 @@ export function requireStringifiedBigInt(parameterValue: string, parameterName: 
 
 /**
  * @throws Throws a type error if the parameter value is not a hexadecimal string.
+ * If 'prefix' is not defined and set to 'false', the string must start with '0x' or '0X'
+ * followed by one or more hexadecimal digits (0-9, a-f, A-F).
  * @param parameterValue The parameter value.
  * @param parameterName The parameter name.
+ * @param prefix A boolean to include or not a '0x' or '0X' prefix.
  */
-export function requireHexadecimal(parameterValue: string, parameterName: string) {
-    if (!isHexadecimal(parameterValue)) {
+export function requireHexadecimal(parameterValue: string, parameterName: string, prefix = true) {
+    if (!isHexadecimal(parameterValue, prefix)) {
         throw new TypeError(`Parameter '${parameterName}' is not a hexadecimal string`)
     }
 }

--- a/packages/utils/src/type-checks.ts
+++ b/packages/utils/src/type-checks.ts
@@ -14,6 +14,7 @@ const supportedTypes = [
     "function",
     "Array",
     "Uint8Array",
+    "Buffer",
     "object",
     "bigint",
     "stringified-bigint",
@@ -82,6 +83,14 @@ export function isUint8Array(value: any): boolean {
 }
 
 /**
+ * Returns true if the value is a Buffer instance, false otherwise.
+ * @param value The value to be checked.
+ */
+export function isBuffer(value: any): boolean {
+    return Buffer.isBuffer(value)
+}
+
+/**
  * Returns true if the value is a bigint, false otherwise.
  * @param value The value to be checked.
  */
@@ -111,11 +120,17 @@ export function isStringifiedBigInt(value: any): boolean {
 
 /**
  * Checks if a string is a valid hexadecimal string representation.
- * The string must start with '0x' or '0X' followed by one or more hexadecimal digits (0-9, a-f, A-F).
+ * If 'prefix' is not defined and set to 'false', the string must start with '0x' or '0X'
+ * followed by one or more hexadecimal digits (0-9, a-f, A-F).
  * @param value The string to be tested.
+ * @param prefix A boolean to include or not a '0x' or '0X' prefix.
  */
-export function isHexadecimal(value: any) {
-    return /^(0x|0X)[0-9a-fA-F]+$/.test(value)
+export function isHexadecimal(value: any, prefix = true) {
+    if (prefix) {
+        return /^(0x|0X)[0-9a-fA-F]+$/.test(value)
+    }
+
+    return /^[0-9a-fA-F]+$/.test(value)
 }
 
 /**
@@ -127,13 +142,7 @@ export function isHexadecimal(value: any) {
  * @param value The value to check.
  */
 export function isBigNumberish(value: any): boolean {
-    return (
-        isNumber(value) ||
-        isBigInt(value) ||
-        isStringifiedBigInt(value) ||
-        isHexadecimal(value) ||
-        Buffer.isBuffer(value)
-    )
+    return isNumber(value) || isBigInt(value) || isStringifiedBigInt(value) || isHexadecimal(value) || isBuffer(value)
 }
 
 /**
@@ -153,6 +162,8 @@ export function isType(value: any, type: SupportedType): boolean {
             return isArray(value)
         case "Uint8Array":
             return isUint8Array(value)
+        case "Buffer":
+            return isBuffer(value)
         case "object":
             return isObject(value)
         case "bigint":

--- a/packages/utils/src/type-checks.ts
+++ b/packages/utils/src/type-checks.ts
@@ -121,7 +121,7 @@ export function isStringifiedBigInt(value: any): boolean {
 /**
  * Checks if a string is a valid hexadecimal string representation.
  * If 'prefix' is 'true', the string must start with '0x' or '0X' followed by one or more
- * hexadecimal digits (0-9, a-f, A-F), otherwise no prefix is needed. 'prefix' is optional and
+ * hexadecimal digits (0-9, a-f, A-F), otherwise no prefix is expected. 'prefix' is optional and
  * if its value it is not explicitly defined it will be set to 'true' by default.
  * @param value The string to be tested.
  * @param prefix A boolean to include or not a '0x' or '0X' prefix.

--- a/packages/utils/src/type-checks.ts
+++ b/packages/utils/src/type-checks.ts
@@ -120,8 +120,9 @@ export function isStringifiedBigInt(value: any): boolean {
 
 /**
  * Checks if a string is a valid hexadecimal string representation.
- * If 'prefix' is not defined and set to 'false', the string must start with '0x' or '0X'
- * followed by one or more hexadecimal digits (0-9, a-f, A-F).
+ * If 'prefix' is 'true', the string must start with '0x' or '0X' followed by one or more
+ * hexadecimal digits (0-9, a-f, A-F), otherwise no prefix is needed. 'prefix' is optional and
+ * if its value it is not explicitly defined it will be set to 'true' by default.
  * @param value The string to be tested.
  * @param prefix A boolean to include or not a '0x' or '0X' prefix.
  */

--- a/packages/utils/tests/conversions.test.ts
+++ b/packages/utils/tests/conversions.test.ts
@@ -4,9 +4,13 @@ import {
     bigIntToHexadecimal,
     bigNumberishToBigInt,
     bigNumberishToBuffer,
+    bufferToHexadecimal,
     hexadecimalToBigInt,
+    hexadecimalToBuffer,
     leBigIntToBuffer,
-    leBufferToBigInt
+    leBufferToBigInt,
+    leBufferToHexadecimal,
+    leHexadecimalToBuffer
 } from "../src/conversions"
 
 describe("Conversions", () => {
@@ -100,6 +104,58 @@ describe("Conversions", () => {
             const result = bigNumberishToBigInt(Buffer.from(testBytes1))
 
             expect(result).toBe(testBigInt1BE)
+        })
+    })
+
+    describe("# bufferToHexadecimal", () => {
+        it("Should convert a BE buffer to a hexadecimal string", async () => {
+            const result = bufferToHexadecimal(Buffer.from(testBytes1))
+
+            expect(result).toBe(testHex1BE.slice(2))
+        })
+
+        it("Should throw an error if the input is not a valid buffer (BE)", async () => {
+            const fun = () => bufferToHexadecimal(1 as any)
+
+            expect(fun).toThrow("Parameter 'value' is none of the following types: Buffer, Uint8Array")
+        })
+
+        it("Should convert a LE buffer to a hexadecimal string", async () => {
+            const result = leBufferToHexadecimal(Buffer.from(testBytes1))
+
+            expect(result).toBe(testHex1LE.slice(2))
+        })
+
+        it("Should throw an error if the input is not a valid buffer (LE)", async () => {
+            const fun = () => leBufferToHexadecimal(1 as any)
+
+            expect(fun).toThrow("Parameter 'value' is none of the following types: Buffer, Uint8Array")
+        })
+    })
+
+    describe("# hexadecimalToBuffer", () => {
+        it("Should convert a BE hexadecimal string to a buffer", async () => {
+            const result = hexadecimalToBuffer(testHex1BE.slice(2))
+
+            expect(result).toStrictEqual(Buffer.from(testBytes1))
+        })
+
+        it("Should throw an error if the input is not a valid hexadecimal (BE)", async () => {
+            const fun = () => hexadecimalToBuffer("0x12")
+
+            expect(fun).toThrow("Parameter 'value' is not a hexadecimal string")
+        })
+
+        it("Should convert a LE hexadecimal string to a buffer", async () => {
+            const result = leHexadecimalToBuffer(testHex1LE.slice(2))
+
+            expect(result).toStrictEqual(Buffer.from(testBytes1))
+        })
+
+        it("Should throw an error if the input is not a valid hexadecimal (LE)", async () => {
+            const fun = () => leHexadecimalToBuffer("0x12")
+
+            expect(fun).toThrow("Parameter 'value' is not a hexadecimal string")
         })
     })
 

--- a/packages/utils/tests/conversions.test.ts
+++ b/packages/utils/tests/conversions.test.ts
@@ -8,9 +8,7 @@ import {
     hexadecimalToBigInt,
     hexadecimalToBuffer,
     leBigIntToBuffer,
-    leBufferToBigInt,
-    leBufferToHexadecimal,
-    leHexadecimalToBuffer
+    leBufferToBigInt
 } from "../src/conversions"
 
 describe("Conversions", () => {
@@ -119,18 +117,6 @@ describe("Conversions", () => {
 
             expect(fun).toThrow("Parameter 'value' is none of the following types: Buffer, Uint8Array")
         })
-
-        it("Should convert a LE buffer to a hexadecimal string", async () => {
-            const result = leBufferToHexadecimal(Buffer.from(testBytes1))
-
-            expect(result).toBe(testHex1LE.slice(2))
-        })
-
-        it("Should throw an error if the input is not a valid buffer (LE)", async () => {
-            const fun = () => leBufferToHexadecimal(1 as any)
-
-            expect(fun).toThrow("Parameter 'value' is none of the following types: Buffer, Uint8Array")
-        })
     })
 
     describe("# hexadecimalToBuffer", () => {
@@ -142,18 +128,6 @@ describe("Conversions", () => {
 
         it("Should throw an error if the input is not a valid hexadecimal (BE)", async () => {
             const fun = () => hexadecimalToBuffer("0x12")
-
-            expect(fun).toThrow("Parameter 'value' is not a hexadecimal string")
-        })
-
-        it("Should convert a LE hexadecimal string to a buffer", async () => {
-            const result = leHexadecimalToBuffer(testHex1LE.slice(2))
-
-            expect(result).toStrictEqual(Buffer.from(testBytes1))
-        })
-
-        it("Should throw an error if the input is not a valid hexadecimal (LE)", async () => {
-            const fun = () => leHexadecimalToBuffer("0x12")
 
             expect(fun).toThrow("Parameter 'value' is not a hexadecimal string")
         })

--- a/packages/utils/tests/error-handlers.test.ts
+++ b/packages/utils/tests/error-handlers.test.ts
@@ -2,6 +2,7 @@ import {
     requireArray,
     requireBigInt,
     requireBigNumberish,
+    requireBuffer,
     requireDefined,
     requireFunction,
     requireHexadecimal,
@@ -70,6 +71,18 @@ describe("# error-handlers", () => {
 
     it("Should not throw an error if the parameter is a Uint8Array", () => {
         const fun = () => requireUint8Array(new Uint8Array([]), "parameter")
+
+        expect(fun).not.toThrow()
+    })
+
+    it("Should throw an error if the parameter is not a Buffer", () => {
+        const fun = () => requireBuffer([] as any, "parameter")
+
+        expect(fun).toThrow("Parameter 'parameter' is not a Buffer instance")
+    })
+
+    it("Should not throw an error if the parameter is a Buffer", () => {
+        const fun = () => requireBuffer(Buffer.from("buffer"), "parameter")
 
         expect(fun).not.toThrow()
     })

--- a/packages/utils/tests/type-checks.test.ts
+++ b/packages/utils/tests/type-checks.test.ts
@@ -2,6 +2,7 @@ import {
     isArray,
     isBigInt,
     isBigNumberish,
+    isBuffer,
     isFunction,
     isHexadecimal,
     isNumber,
@@ -46,12 +47,20 @@ describe("# type-checks", () => {
         expect(isArray(1)).toBeFalsy()
     })
 
-    it("Should return true if the value is a Uint8Array instance", () => {
+    it("Should return true if the value is a Uint8Array", () => {
         expect(isUint8Array(new Uint8Array([]))).toBeTruthy()
     })
 
     it("Should return false if the value is not a Uint8Array", () => {
         expect(isUint8Array(1)).toBeFalsy()
+    })
+
+    it("Should return true if the value is a Buffer", () => {
+        expect(isBuffer(Buffer.from("buffer"))).toBeTruthy()
+    })
+
+    it("Should return false if the value is not a Buffer", () => {
+        expect(isBuffer(1)).toBeFalsy()
     })
 
     it("Should return true if the value is an object", () => {
@@ -105,6 +114,7 @@ describe("# type-checks", () => {
         expect(isType(() => true, "function")).toBeTruthy()
         expect(isType([], "Array")).toBeTruthy()
         expect(isType(new Uint8Array([]), "Uint8Array")).toBeTruthy()
+        expect(isType(Buffer.from("buffer"), "Buffer")).toBeTruthy()
         expect(isType({}, "object")).toBeTruthy()
         expect(isType(BigInt(1), "bigint")).toBeTruthy()
         expect(isType("1242342342342342", "stringified-bigint")).toBeTruthy()
@@ -118,6 +128,7 @@ describe("# type-checks", () => {
         expect(isType(1, "function")).toBeFalsy()
         expect(isType(1, "Array")).toBeFalsy()
         expect(isType(1, "Uint8Array")).toBeFalsy()
+        expect(isType(1, "Buffer")).toBeFalsy()
         expect(isType(1, "object")).toBeFalsy()
         expect(isType(1, "bigint")).toBeFalsy()
         expect(isType(1, "stringified-bigint")).toBeFalsy()


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

This PR adds 4 functions to the `conversions` module to convert hexadecimal strings to buffers and vice versa, both using little-endian and big-endian byte orders.

It also adds `isBuffer` to the `type-checks` module, and a `requireBuffer` to the `error-handlers` module.

Finally, it adds a new `prefix` parameter to the `isHexadecimal` and `requireHexadecimal` functions. It is an optional boolean (set to `true` by default) to consider or not the `0x` or `0X` prefix in a hexadecimal string.

## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

Closes #189

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have run `yarn prettier` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] Any dependent changes have been merged and published in downstream modules
