### PR TITLE
Generate a random EdDSA private key if it is not provided by devs

### DIFF
--- a/packages/eddsa-poseidon/src/eddsa-poseidon.ts
+++ b/packages/eddsa-poseidon/src/eddsa-poseidon.ts
@@ -10,13 +10,15 @@ import {
     unpackPoint
 } from "@zk-kit/baby-jubjub"
 import type { BigNumberish } from "@zk-kit/utils"
+import { crypto } from "@zk-kit/utils"
 import { bigNumberishToBigInt, leBigIntToBuffer, leBufferToBigInt } from "@zk-kit/utils/conversions"
 import { requireBigNumberish } from "@zk-kit/utils/error-handlers"
 import F1Field from "@zk-kit/utils/f1-field"
 import * as scalar from "@zk-kit/utils/scalar"
+import { Buffer } from "buffer"
 import { poseidon5 } from "poseidon-lite/poseidon5"
 import { Signature } from "./types"
-import { checkMessage, checkPrivateKey, isPoint, isSignature, pruneBuffer, hash as blake } from "./utils"
+import { hash as blake, checkMessage, checkPrivateKey, isPoint, isSignature, pruneBuffer } from "./utils"
 
 /**
  * Derives a secret scalar from a given EdDSA private key.
@@ -188,9 +190,10 @@ export class EdDSAPoseidon {
 
     /**
      * Initializes a new instance, deriving necessary cryptographic parameters from the provided private key.
+     * If the private key is not passed as a parameter, a random 32-byte key is generated.
      * @param privateKey The private key used for signing and public key derivation.
      */
-    constructor(privateKey: BigNumberish) {
+    constructor(privateKey: BigNumberish = Buffer.from(crypto.getRandomValues(32))) {
         this.privateKey = privateKey
         this.secretScalar = deriveSecretScalar(privateKey)
         this.publicKey = derivePublicKey(privateKey)

--- a/packages/eddsa-poseidon/tests/index.test.ts
+++ b/packages/eddsa-poseidon/tests/index.test.ts
@@ -260,4 +260,16 @@ describe("EdDSAPoseidon", () => {
         expect(eddsa.packedPublicKey).toBe(packPublicKey(eddsa.publicKey))
         expect(eddsa.verifySignature(message, signature)).toBeTruthy()
     })
+
+    it("Should create an EdDSAPoseidon instance with a random private key", async () => {
+        const eddsa = new EdDSAPoseidon()
+
+        const signature = eddsa.signMessage(message)
+
+        expect(eddsa.privateKey).toBeInstanceOf(Buffer)
+        expect(eddsa.privateKey).toHaveLength(32)
+        expect(eddsa.secretScalar).toBe(deriveSecretScalar(eddsa.privateKey))
+        expect(eddsa.packedPublicKey).toBe(packPublicKey(eddsa.publicKey))
+        expect(eddsa.verifySignature(message, signature)).toBeTruthy()
+    })
 })


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

If no private key is passed to the constructor, a 32-byte random buffer will be generated for it.

## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

Closes #183

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have run `yarn prettier` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] Any dependent changes have been merged and published in downstream modules
