### PR TITLE
fix(eddsa-poseidon): eddsa-poseidon should accept Points and Signatures in numeric form

### DIFF
--- a/packages/eddsa-poseidon/src/utils.ts
+++ b/packages/eddsa-poseidon/src/utils.ts
@@ -2,7 +2,7 @@ import { Point } from "@zk-kit/baby-jubjub"
 import type { BigNumberish } from "@zk-kit/utils"
 import { bigNumberishToBigInt, bigNumberishToBuffer, bufferToBigInt } from "@zk-kit/utils/conversions"
 import { requireTypes } from "@zk-kit/utils/error-handlers"
-import { isArray, isBigNumberish, isObject, isStringifiedBigInt } from "@zk-kit/utils/type-checks"
+import { isArray, isBigNumberish, isObject, isBigNumber } from "@zk-kit/utils/type-checks"
 import { Buffer } from "buffer"
 import { Blake512 } from "./blake"
 import { Signature } from "./types"
@@ -27,7 +27,7 @@ export function pruneBuffer(buff: Buffer): Buffer {
  * @returns True if the object is a valid point, false otherwise.
  */
 export function isPoint(point: Point): boolean {
-    return isArray(point) && point.length === 2 && isStringifiedBigInt(point[0]) && isStringifiedBigInt(point[1])
+    return isArray(point) && point.length === 2 && isBigNumber(point[0]) && isBigNumber(point[1])
 }
 
 /**
@@ -41,7 +41,7 @@ export function isSignature(signature: Signature): boolean {
         Object.prototype.hasOwnProperty.call(signature, "R8") &&
         Object.prototype.hasOwnProperty.call(signature, "S") &&
         isPoint(signature.R8) &&
-        isStringifiedBigInt(signature.S)
+        isBigNumber(signature.S)
     )
 }
 

--- a/packages/eddsa-poseidon/tests/index.test.ts
+++ b/packages/eddsa-poseidon/tests/index.test.ts
@@ -2,9 +2,10 @@ import { babyjub, eddsa } from "circomlibjs"
 import { Buffer } from "buffer"
 import { crypto } from "@zk-kit/utils"
 import { utils } from "ffjavascript"
-import { r, packPoint } from "@zk-kit/baby-jubjub"
+import { r, packPoint, Point } from "@zk-kit/baby-jubjub"
 import {
     EdDSAPoseidon,
+    Signature,
     derivePublicKey,
     deriveSecretScalar,
     packPublicKey,
@@ -12,6 +13,18 @@ import {
     unpackPublicKey,
     verifySignature
 } from "../src"
+import { isPoint, isSignature } from "../src/utils"
+
+function numericPoint(publicKey: Point): Point<bigint> {
+    return [BigInt(publicKey[0]), BigInt(publicKey[1])];
+}
+
+function numericSignature(signature: Signature): Signature<bigint> {
+    return {
+        R8: [BigInt(signature.R8[0]), BigInt(signature.R8[1])],
+        S: BigInt(signature.S)
+    }
+}
 
 describe("EdDSAPoseidon", () => {
     const privateKey = "secret"
@@ -144,9 +157,16 @@ describe("EdDSAPoseidon", () => {
         expect(fun).toThrow(`Parameter 'message' is none of the following types: bignumberish, string`)
     })
 
-    it("Should verify a signature", async () => {
+    it("Should verify a signature (stringified)", async () => {
         const publicKey = derivePublicKey(privateKey)
         const signature = signMessage(privateKey, message)
+
+        expect(verifySignature(message, signature, publicKey)).toBeTruthy()
+    })
+
+    it("Should verify a signature (numeric)", async () => {
+        const publicKey = numericPoint(derivePublicKey(privateKey))
+        const signature = numericSignature(signMessage(privateKey, message))
 
         expect(verifySignature(message, signature, publicKey)).toBeTruthy()
     })
@@ -207,8 +227,18 @@ describe("EdDSAPoseidon", () => {
         }
     })
 
-    it("Should pack a public key", async () => {
+    it("Should pack a public key (stringified)", async () => {
         const publicKey = derivePublicKey(privateKey)
+
+        const packedPublicKey = packPublicKey(publicKey)
+
+        const expectedPackedPublicKey = babyjub.packPoint([BigInt(publicKey[0]), BigInt(publicKey[1])])
+
+        expect(packedPublicKey).toBe(utils.leBuff2int(expectedPackedPublicKey).toString())
+    })
+
+    it("Should pack a public key (numeric)", async () => {
+        const publicKey = numericPoint(derivePublicKey(privateKey))
 
         const packedPublicKey = packPublicKey(publicKey)
 
@@ -271,5 +301,30 @@ describe("EdDSAPoseidon", () => {
         expect(eddsa.secretScalar).toBe(deriveSecretScalar(eddsa.privateKey))
         expect(eddsa.packedPublicKey).toBe(packPublicKey(eddsa.publicKey))
         expect(eddsa.verifySignature(message, signature)).toBeTruthy()
+    })
+})
+
+describe("eddsa-poseidon.utils", () => {
+
+    it("Should identify points in different forms", async () => {
+        expect(isPoint(undefined as any as Point)).toBeFalsy()
+        expect(isPoint(123 as any as Point)).toBeFalsy()
+        expect(isPoint(["1", "2"])).toBeTruthy()
+        expect(isPoint(["0xa1", "0xb2"])).toBeTruthy()
+        expect(isPoint(["1", BigInt("2")])).toBeTruthy()
+        expect(isPoint([BigInt("1"), "2"])).toBeTruthy()
+        expect(isPoint([BigInt("1"), BigInt("2")])).toBeTruthy()
+        expect(isPoint(["1", "2", "3"] as any as Point)).toBeFalsy()
+        expect(isPoint({x: "1", y: "2"} as any as Point)).toBeFalsy()
+    })
+
+    it("Should identify signatures in different forms", async () => {
+        expect(isSignature(undefined as any as Signature)).toBeFalsy()
+        expect(isSignature(123 as any as Signature)).toBeFalsy()
+        expect(isSignature({R8: ["1", "2"], S: "3"})).toBeTruthy()
+        expect(isSignature({R8: ["0xa1", "0xb2"], S: "0xc3"})).toBeTruthy()
+        expect(isSignature({R8: [BigInt("1"), BigInt("2")], S: BigInt("3")})).toBeTruthy()
+        expect(isSignature({R8: ["1", "2", "3"], S: "4"} as any as Signature)).toBeFalsy()
+        expect(isSignature({R8: ["1", "2"], SS: "3"} as any as Signature)).toBeFalsy()
     })
 })

--- a/packages/eddsa-poseidon/tests/index.test.ts
+++ b/packages/eddsa-poseidon/tests/index.test.ts
@@ -16,7 +16,7 @@ import {
 import { isPoint, isSignature } from "../src/utils"
 
 function numericPoint(publicKey: Point): Point<bigint> {
-    return [BigInt(publicKey[0]), BigInt(publicKey[1])];
+    return [BigInt(publicKey[0]), BigInt(publicKey[1])]
 }
 
 function numericSignature(signature: Signature): Signature<bigint> {
@@ -305,7 +305,6 @@ describe("EdDSAPoseidon", () => {
 })
 
 describe("eddsa-poseidon.utils", () => {
-
     it("Should identify points in different forms", async () => {
         expect(isPoint(undefined as any as Point)).toBeFalsy()
         expect(isPoint(123 as any as Point)).toBeFalsy()
@@ -315,16 +314,16 @@ describe("eddsa-poseidon.utils", () => {
         expect(isPoint([BigInt("1"), "2"])).toBeTruthy()
         expect(isPoint([BigInt("1"), BigInt("2")])).toBeTruthy()
         expect(isPoint(["1", "2", "3"] as any as Point)).toBeFalsy()
-        expect(isPoint({x: "1", y: "2"} as any as Point)).toBeFalsy()
+        expect(isPoint({ x: "1", y: "2" } as any as Point)).toBeFalsy()
     })
 
     it("Should identify signatures in different forms", async () => {
         expect(isSignature(undefined as any as Signature)).toBeFalsy()
         expect(isSignature(123 as any as Signature)).toBeFalsy()
-        expect(isSignature({R8: ["1", "2"], S: "3"})).toBeTruthy()
-        expect(isSignature({R8: ["0xa1", "0xb2"], S: "0xc3"})).toBeTruthy()
-        expect(isSignature({R8: [BigInt("1"), BigInt("2")], S: BigInt("3")})).toBeTruthy()
-        expect(isSignature({R8: ["1", "2", "3"], S: "4"} as any as Signature)).toBeFalsy()
-        expect(isSignature({R8: ["1", "2"], SS: "3"} as any as Signature)).toBeFalsy()
+        expect(isSignature({ R8: ["1", "2"], S: "3" })).toBeTruthy()
+        expect(isSignature({ R8: ["0xa1", "0xb2"], S: "0xc3" })).toBeTruthy()
+        expect(isSignature({ R8: [BigInt("1"), BigInt("2")], S: BigInt("3") })).toBeTruthy()
+        expect(isSignature({ R8: ["1", "2", "3"], S: "4" } as any as Signature)).toBeFalsy()
+        expect(isSignature({ R8: ["1", "2"], SS: "3" } as any as Signature)).toBeFalsy()
     })
 })

--- a/packages/utils/src/error-handlers.ts
+++ b/packages/utils/src/error-handlers.ts
@@ -12,6 +12,7 @@ import {
     SupportedType,
     isArray,
     isBigInt,
+    isBigNumber,
     isBigNumberish,
     isBuffer,
     isDefined,
@@ -149,6 +150,17 @@ export function requireStringifiedBigInt(parameterValue: string, parameterName: 
 export function requireHexadecimal(parameterValue: string, parameterName: string, prefix = true) {
     if (!isHexadecimal(parameterValue, prefix)) {
         throw new TypeError(`Parameter '${parameterName}' is not a hexadecimal string`)
+    }
+}
+
+/**
+ * @throws Throws a type error if the parameter value is not a bignumber.
+ * @param parameterValue The parameter value.
+ * @param parameterName The parameter name.
+ */
+export function requireBigNumber(parameterValue: any, parameterName: string) {
+    if (!isBigNumber(parameterValue)) {
+        throw new TypeError(`Parameter '${parameterName}' is not a bignumber`)
     }
 }
 

--- a/packages/utils/src/type-checks.ts
+++ b/packages/utils/src/type-checks.ts
@@ -143,7 +143,7 @@ export function isHexadecimal(value: any, prefix = true) {
  * @param value The value to check.
  */
 export function isBigNumber(value: any): boolean {
-    return isBigInt(value) || isStringifiedBigInt(value);
+    return isBigInt(value) || isStringifiedBigInt(value)
 }
 
 /**

--- a/packages/utils/src/type-checks.ts
+++ b/packages/utils/src/type-checks.ts
@@ -21,6 +21,7 @@ const supportedTypes = [
     "bigint",
     "stringified-bigint",
     "hexadecimal",
+    "bignumber",
     "bignumberish"
 ] as const
 
@@ -185,6 +186,8 @@ export function isType(value: any, type: SupportedType): boolean {
             return isStringifiedBigInt(value)
         case "hexadecimal":
             return isHexadecimal(value)
+        case "bignumber":
+            return isBigNumber(value)
         case "bignumberish":
             return isBigNumberish(value)
         default:

--- a/packages/utils/src/type-checks.ts
+++ b/packages/utils/src/type-checks.ts
@@ -137,6 +137,16 @@ export function isHexadecimal(value: any, prefix = true) {
 }
 
 /**
+ * Checks if the given value can be considered as BigNumber.
+ * A value is considered a BigNumber if it is a bigint or a string
+ * that can be converted to a bigint (via `Bigint(s)`).
+ * @param value The value to check.
+ */
+export function isBigNumber(value: any): boolean {
+    return isBigInt(value) || isStringifiedBigInt(value);
+}
+
+/**
  * Checks if the given value can be considered as BigNumberish.
  * A value is considered BigNumberish if it meets
  * any of the following conditions: it's a number, a bigint, a string

--- a/packages/utils/tests/error-handlers.test.ts
+++ b/packages/utils/tests/error-handlers.test.ts
@@ -1,6 +1,7 @@
 import {
     requireArray,
     requireBigInt,
+    requireBigNumber,
     requireBigNumberish,
     requireBuffer,
     requireDefined,
@@ -145,6 +146,12 @@ describe("# error-handlers", () => {
         const fun = () => requireStringifiedBigInt("0x12", "parameter")
 
         expect(fun).not.toThrow()
+    })
+
+    it("Should throw an error if the parameter is not a bignumber", () => {
+        const fun = () => requireBigNumber("string", "parameter")
+
+        expect(fun).toThrow("Parameter 'parameter' is not a bignumber")
     })
 
     it("Should throw an error if the parameter is not a bignumber-ish", () => {

--- a/packages/utils/tests/type-checks.test.ts
+++ b/packages/utils/tests/type-checks.test.ts
@@ -2,6 +2,7 @@ import { Buffer } from "buffer"
 import {
     isArray,
     isBigInt,
+    isBigNumber,
     isBigNumberish,
     isBuffer,
     isFunction,
@@ -95,6 +96,14 @@ describe("# type-checks", () => {
 
     it("Should return false if the value is not a hexadecimal", () => {
         expect(isHexadecimal("12")).toBeFalsy()
+    })
+
+    it("Should return true if the value is a bignumber", () => {
+        expect(isBigNumber(1)).toBeFalsy()
+        expect(isBigNumber("1")).toBeTruthy()
+        expect(isBigNumber(BigInt("1"))).toBeTruthy()
+        expect(isBigNumber("0x12")).toBeTruthy()
+        expect(isBigNumber(Buffer.from("0x12"))).toBeFalsy()
     })
 
     it("Should return true if the value is a bignumber-ish", () => {

--- a/packages/utils/tests/type-checks.test.ts
+++ b/packages/utils/tests/type-checks.test.ts
@@ -129,6 +129,9 @@ describe("# type-checks", () => {
         expect(isType(BigInt(1), "bigint")).toBeTruthy()
         expect(isType("1242342342342342", "stringified-bigint")).toBeTruthy()
         expect(isType("0x12", "hexadecimal")).toBeTruthy()
+        expect(isType(BigInt(1), "bignumber")).toBeTruthy()
+        expect(isType("123", "bignumber")).toBeTruthy()
+        expect(isType("0xa123", "bignumber")).toBeTruthy()
         expect(isType(1, "bignumberish")).toBeTruthy()
     })
 
@@ -143,6 +146,8 @@ describe("# type-checks", () => {
         expect(isType(1, "bigint")).toBeFalsy()
         expect(isType(1, "stringified-bigint")).toBeFalsy()
         expect(isType(1, "hexadecimal")).toBeFalsy()
+        expect(isType(1, "bignumber")).toBeFalsy()
+        expect(isType("string", "bignumber")).toBeFalsy()
         expect(isType("string", "bignumberish")).toBeFalsy()
         expect(isType(1, "type" as any)).toBeFalsy()
     })


### PR DESCRIPTION

## Description

Added `isBigNumber` and `requireBigNumber` in zk-kit/utils
Used `isBigNumber` in `isPoint` and `isSignature` in zk-kit/eddsa-poseidon to make them more accepting

## Related Issue(s)

Fixes #198
