### PR TITLE
feat(eddsa-poseidon): add packSignature and unpackSignature to eddsa-poseidon

### DIFF
--- a/packages/eddsa-poseidon/src/eddsa-poseidon.ts
+++ b/packages/eddsa-poseidon/src/eddsa-poseidon.ts
@@ -198,8 +198,8 @@ export function packSignature(signature: Signature): Buffer {
 
     const packedR8 = packPoint(numericSignature.R8)
     const packedBytes = Buffer.alloc(64)
-    packedBytes.set(leBigIntToBuffer(packedR8), 0)
-    packedBytes.set(leBigIntToBuffer(numericSignature.S), 32)
+    packedBytes.set(leBigIntToBuffer(packedR8, 32), 0)
+    packedBytes.set(leBigIntToBuffer(numericSignature.S, 32), 32)
     return packedBytes
 }
 

--- a/packages/eddsa-poseidon/src/eddsa-poseidon.ts
+++ b/packages/eddsa-poseidon/src/eddsa-poseidon.ts
@@ -10,7 +10,7 @@ import {
     unpackPoint
 } from "@zk-kit/baby-jubjub"
 import type { BigNumberish } from "@zk-kit/utils"
-import { crypto } from "@zk-kit/utils"
+import { crypto, requireBuffer } from "@zk-kit/utils"
 import { bigNumberishToBigInt, leBigIntToBuffer, leBufferToBigInt } from "@zk-kit/utils/conversions"
 import { requireBigNumberish } from "@zk-kit/utils/error-handlers"
 import F1Field from "@zk-kit/utils/f1-field"
@@ -172,6 +172,64 @@ export function unpackPublicKey(publicKey: BigNumberish): Point<string> {
     }
 
     return [unpackedPublicKey[0].toString(), unpackedPublicKey[1].toString()]
+}
+
+/**
+ * Packs an EdDSA signature into a buffer of 64 bytes for efficient storage.
+ * Use {@link unpackSignature} to reverse the process without needing to know
+ * the details of the format.
+ * 
+ * The buffer contains the R8 point packed int 32 bytes (via
+ * {@link packSignature}) followed by the S scalar.  All encodings are
+ * little-endian.
+ * 
+ * @param signature the signature to pack
+ * @returns a 64 byte buffer containing the packed signature
+ */
+export function packSignature(signature: Signature): Buffer {
+    if (
+        !isSignature(signature) ||
+        !inCurve(signature.R8) ||
+        BigInt(signature.S) >= subOrder
+    ) {
+        throw new Error("Invalid signature")
+    }
+
+    const numericSignature: Signature<bigint> = {
+        R8: signature.R8.map((c) => BigInt(c)) as Point<bigint>,
+        S: BigInt(signature.S)
+    }
+
+    const packedR8 = packPoint(numericSignature.R8)
+    const packedBytes = Buffer.alloc(64)
+    packedBytes.set(leBigIntToBuffer(packedR8), 0)
+    packedBytes.set(leBigIntToBuffer(numericSignature.S), 32)
+    return packedBytes
+}
+  
+/**
+ * Unpacks a signature produced by {@link #packSignature}.  See that function
+ * for the details of the format.
+ * 
+ * @param packedSignature the 64 byte buffer to unpack 
+ * @returns a Signature with numbers in string form
+ */
+export function unpackSignature(packedSignature: Buffer): Signature<string> {
+    requireBuffer(packedSignature, "packedSignature")
+    if (packedSignature.length !== 64) {
+        throw new Error("Packed signature must be 64 bytes")
+    }
+
+    const sliceR8 = packedSignature.subarray(0, 32)
+    const sliceS = packedSignature.subarray(32, 64)
+    const unpackedR8 = unpackPoint(leBufferToBigInt(sliceR8))
+    if (unpackedR8 === null) {
+        throw new Error(`Invalid packed signature point ${sliceS.toString("hex")}.`)
+    }
+    return {
+        R8: [unpackedR8[0].toString(), unpackedR8[1].toString()],
+        S: leBufferToBigInt(sliceS).toString()
+    }
 }
 
 /**

--- a/packages/eddsa-poseidon/src/eddsa-poseidon.ts
+++ b/packages/eddsa-poseidon/src/eddsa-poseidon.ts
@@ -178,20 +178,16 @@ export function unpackPublicKey(publicKey: BigNumberish): Point<string> {
  * Packs an EdDSA signature into a buffer of 64 bytes for efficient storage.
  * Use {@link unpackSignature} to reverse the process without needing to know
  * the details of the format.
- * 
+ *
  * The buffer contains the R8 point packed int 32 bytes (via
  * {@link packSignature}) followed by the S scalar.  All encodings are
  * little-endian.
- * 
+ *
  * @param signature the signature to pack
  * @returns a 64 byte buffer containing the packed signature
  */
 export function packSignature(signature: Signature): Buffer {
-    if (
-        !isSignature(signature) ||
-        !inCurve(signature.R8) ||
-        BigInt(signature.S) >= subOrder
-    ) {
+    if (!isSignature(signature) || !inCurve(signature.R8) || BigInt(signature.S) >= subOrder) {
         throw new Error("Invalid signature")
     }
 
@@ -206,12 +202,12 @@ export function packSignature(signature: Signature): Buffer {
     packedBytes.set(leBigIntToBuffer(numericSignature.S), 32)
     return packedBytes
 }
-  
+
 /**
  * Unpacks a signature produced by {@link #packSignature}.  See that function
  * for the details of the format.
- * 
- * @param packedSignature the 64 byte buffer to unpack 
+ *
+ * @param packedSignature the 64 byte buffer to unpack
  * @returns a Signature with numbers in string form
  */
 export function unpackSignature(packedSignature: Buffer): Signature<string> {

--- a/packages/eddsa-poseidon/tests/index.test.ts
+++ b/packages/eddsa-poseidon/tests/index.test.ts
@@ -295,7 +295,17 @@ describe("EdDSAPoseidon", () => {
         expect(packedSignature).toEqual(circomlibPackedSignature)
     })
 
-    // TODO(artwyman): Add test case for numericSignature after #200 lands
+    it("Should pack a signature (numeric)", async () => {
+        const signature = signMessage(privateKey, message)
+
+        const packedSignature = packSignature(numericSignature(signature))
+        expect(packedSignature).toHaveLength(64)
+
+        const circomlibSignature = eddsa.signPoseidon(privateKey, message)
+        const circomlibPackedSignature = eddsa.packSignature(circomlibSignature)
+
+        expect(packedSignature).toEqual(circomlibPackedSignature)
+    })
 
     it("Should still pack an incorrect signature", async () => {
         const signature = signMessage(privateKey, message)

--- a/packages/eddsa-poseidon/tests/index.test.ts
+++ b/packages/eddsa-poseidon/tests/index.test.ts
@@ -337,6 +337,21 @@ describe("EdDSAPoseidon", () => {
         unpackSignature(packedSignature)
     })
 
+    it("Should handle a signature with values smaller than 32 bytes", async () => {
+        const signature = signMessage(privateKey, message)
+
+        // S is the only value which we can easily make artifically small, since
+        // R8 has to be a point on the curve.
+        // Note that overly-large values also ruled out by the inCurve check on
+        // R8 and the subOrder check on S.
+        signature.S = "3"
+
+        const packedSignature = packSignature(signature)
+
+        const unpackedSignature = unpackSignature(packedSignature)
+        expect(unpackedSignature).toEqual(signature)
+    })
+
     it("Should create an EdDSAPoseidon instance", async () => {
         const eddsa = new EdDSAPoseidon(privateKey)
 


### PR DESCRIPTION
## Description

Signatures are packed into 64 bytes using the same format as circomlibjs.  Unit tests confirm the compatibility of output.

## Other information

There's a TODO in place for one more unit test I'd like to add after #200 lands and fixes the ability to accept signatures in numeric form.

The unpackSignature function returns a `Signature<string>`.  If #199 gets accepted and implemented, it should change to return `Signature<bigint>`.
