### PR TITLE
Restrict EdDSA private-key supported types

### DIFF
--- a/packages/circuits/tests/common.ts
+++ b/packages/circuits/tests/common.ts
@@ -40,7 +40,7 @@ export const circomkit = new Circomkit({
  * @param pubKey A public key generated using genPubKey()
  * @returns The ECDH shared key.
  */
-export const genEcdhSharedKey = (privKey: bigint, pubKey: [bigint, bigint]): Point<bigint> => {
+export const genEcdhSharedKey = (privKey: Buffer | Uint8Array | string, pubKey: [bigint, bigint]): Point<bigint> => {
     const secretScalar = deriveSecretScalar(privKey)
 
     return mulPointEscalar(pubKey, secretScalar) as Point<bigint>

--- a/packages/circuits/tests/ecdh.test.ts
+++ b/packages/circuits/tests/ecdh.test.ts
@@ -1,6 +1,6 @@
-import { WitnessTester } from "circomkit"
 import { derivePublicKey, deriveSecretScalar } from "@zk-kit/eddsa-poseidon"
-import { beBufferToBigInt, crypto } from "@zk-kit/utils"
+import { crypto } from "@zk-kit/utils"
+import { WitnessTester } from "circomkit"
 import { circomkit, genEcdhSharedKey } from "./common"
 
 describe("ECDH Shared Key derivation circuit", () => {
@@ -16,16 +16,14 @@ describe("ECDH Shared Key derivation circuit", () => {
     it("should correctly compute an ECDH shared key", async () => {
         const privateKey1 = crypto.getRandomValues(32)
         const privateKey2 = crypto.getRandomValues(32)
-        const bgPrivateKey1 = beBufferToBigInt(Buffer.from(privateKey1))
-        const bgPrivateKey2 = beBufferToBigInt(Buffer.from(privateKey2))
 
-        const publicKey2 = derivePublicKey(bgPrivateKey2)
+        const publicKey2 = derivePublicKey(privateKey2)
 
         // generate a shared key between the first private key and the second public key
-        const ecdhSharedKey = genEcdhSharedKey(bgPrivateKey1, publicKey2)
+        const ecdhSharedKey = genEcdhSharedKey(privateKey1, publicKey2)
 
         const circuitInputs = {
-            privateKey: deriveSecretScalar(bgPrivateKey1),
+            privateKey: deriveSecretScalar(privateKey1),
             publicKey: publicKey2
         }
 
@@ -35,22 +33,20 @@ describe("ECDH Shared Key derivation circuit", () => {
     it("should generate the same shared key from the same keypairs", async () => {
         const privateKey1 = crypto.getRandomValues(32)
         const privateKey2 = crypto.getRandomValues(32)
-        const bgPrivateKey1 = beBufferToBigInt(Buffer.from(privateKey1))
-        const bgPrivateKey2 = beBufferToBigInt(Buffer.from(privateKey2))
-        const publicKey1 = derivePublicKey(bgPrivateKey1)
-        const publicKey2 = derivePublicKey(bgPrivateKey2)
+        const publicKey1 = derivePublicKey(privateKey1)
+        const publicKey2 = derivePublicKey(privateKey2)
 
         // generate a shared key between the first private key and the second public key
-        const ecdhSharedKey = genEcdhSharedKey(bgPrivateKey1, publicKey2)
-        const ecdhSharedKey2 = genEcdhSharedKey(bgPrivateKey2, publicKey1)
+        const ecdhSharedKey = genEcdhSharedKey(privateKey1, publicKey2)
+        const ecdhSharedKey2 = genEcdhSharedKey(privateKey2, publicKey1)
 
         const circuitInputs = {
-            privateKey: deriveSecretScalar(bgPrivateKey1),
+            privateKey: deriveSecretScalar(privateKey1),
             publicKey: publicKey2
         }
 
         const circuitInputs2 = {
-            privateKey: deriveSecretScalar(bgPrivateKey2),
+            privateKey: deriveSecretScalar(privateKey2),
             publicKey: publicKey1
         }
 
@@ -65,13 +61,12 @@ describe("ECDH Shared Key derivation circuit", () => {
     })
 
     it("should generate the same ECDH key consistently for the same inputs", async () => {
-        const privateKey1 = deriveSecretScalar(Buffer.from(crypto.getRandomValues(32)))
-        const privateKey2 = crypto.getRandomValues(32)
-        const publicKey2 = derivePublicKey(beBufferToBigInt(Buffer.from(privateKey2)))
+        const secretScalar = deriveSecretScalar(crypto.getRandomValues(32))
+        const publicKey = derivePublicKey(crypto.getRandomValues(32))
 
         const circuitInputs = {
-            privateKey: privateKey1,
-            publicKey: publicKey2
+            privateKey: secretScalar,
+            publicKey: publicKey
         }
 
         // calculate first time witness and check contraints

--- a/packages/circuits/tests/ecdh.test.ts
+++ b/packages/circuits/tests/ecdh.test.ts
@@ -66,7 +66,7 @@ describe("ECDH Shared Key derivation circuit", () => {
 
         const circuitInputs = {
             privateKey: secretScalar,
-            publicKey: publicKey
+            publicKey
         }
 
         // calculate first time witness and check contraints

--- a/packages/circuits/tests/eddsa-proof.test.ts
+++ b/packages/circuits/tests/eddsa-proof.test.ts
@@ -6,14 +6,14 @@ import { circomkit } from "./common"
 describe("eddsa-proof", () => {
     let circuit: WitnessTester<["secret", "scope"], ["commitment"]>
 
-    const secret = 3
+    const privateKey = Buffer.from("secret")
     const scope = 2
 
-    const publicKey = derivePublicKey(secret)
+    const publicKey = derivePublicKey(privateKey)
     const commitment = poseidon2(publicKey)
 
     const INPUT = {
-        secret: deriveSecretScalar(secret),
+        secret: deriveSecretScalar(privateKey),
         scope
     }
 

--- a/packages/circuits/tests/poseidon-cipher.test.ts
+++ b/packages/circuits/tests/poseidon-cipher.test.ts
@@ -1,7 +1,7 @@
-import { WitnessTester } from "circomkit"
 import { derivePublicKey } from "@zk-kit/eddsa-poseidon"
 import { Nonce, PlainText, poseidonDecrypt, poseidonEncrypt, poseidonPerm } from "@zk-kit/poseidon-cipher"
-import { beBufferToBigInt, crypto } from "@zk-kit/utils"
+import { crypto } from "@zk-kit/utils"
+import { WitnessTester } from "circomkit"
 import { circomkit, genEcdhSharedKey } from "./common"
 
 describe("poseidon-cipher", () => {
@@ -9,9 +9,8 @@ describe("poseidon-cipher", () => {
         let circuit: WitnessTester<["ciphertext", "nonce", "key"], ["decrypted"]>
 
         const privateKey = crypto.getRandomValues(32)
-        const bgPrivateKey = beBufferToBigInt(Buffer.from(privateKey))
-        const publicKey = derivePublicKey(bgPrivateKey)
-        const encryptionKey = genEcdhSharedKey(bgPrivateKey, publicKey)
+        const publicKey = derivePublicKey(privateKey)
+        const encryptionKey = genEcdhSharedKey(privateKey, publicKey)
 
         const nonce: Nonce = BigInt(5)
 
@@ -99,9 +98,8 @@ describe("poseidon-cipher", () => {
         let circuit: WitnessTester<["ciphertext", "nonce", "key"], ["decrypted"]>
 
         const privateKey = crypto.getRandomValues(32)
-        const bgPrivateKey = beBufferToBigInt(Buffer.from(privateKey))
-        const publicKey = derivePublicKey(bgPrivateKey)
-        const encryptionKey = genEcdhSharedKey(bgPrivateKey, publicKey)
+        const publicKey = derivePublicKey(privateKey)
+        const encryptionKey = genEcdhSharedKey(privateKey, publicKey)
 
         const plainText: PlainText<bigint> = [BigInt(0), BigInt(1)]
         const nonce: Nonce = BigInt(5)
@@ -157,9 +155,8 @@ describe("poseidon-cipher", () => {
         let circuit: WitnessTester<["ciphertext", "nonce", "key"], ["decrypted"]>
 
         const privateKey = crypto.getRandomValues(32)
-        const bgPrivateKey = beBufferToBigInt(Buffer.from(privateKey))
-        const publicKey = derivePublicKey(bgPrivateKey)
-        const encryptionKey = genEcdhSharedKey(bgPrivateKey, publicKey)
+        const publicKey = derivePublicKey(privateKey)
+        const encryptionKey = genEcdhSharedKey(privateKey, publicKey)
 
         const plainText: PlainText<bigint> = [BigInt(0), BigInt(1)]
         const nonce: Nonce = BigInt(5)

--- a/packages/eddsa-poseidon/src/eddsa-poseidon.ts
+++ b/packages/eddsa-poseidon/src/eddsa-poseidon.ts
@@ -27,15 +27,20 @@ import { hash as blake, checkMessage, checkPrivateKey, isPoint, isSignature, pru
 
 /**
  * Derives a secret scalar from a given EdDSA private key.
+ *
  * This process involves hashing the private key with Blake1, pruning the resulting hash to retain the lower 32 bytes,
  * and converting it into a little-endian integer. The use of the secret scalar streamlines the public key generation
  * process by omitting steps 1, 2, and 3 as outlined in RFC 8032 section 5.1.5, enhancing circuit efficiency and simplicity.
  * This method is crucial for fixed-base scalar multiplication operations within the correspondent cryptographic circuit.
- * The private key must be an instance of Buffer, Uint8Array or a string. If you want to pass a bigint, a number or a
- * hexadecimal, be sure to convert them to one of the supported types first. The 'conversions' module in @zk-kit/utils
- * provides a set of functions that may be useful in case you need to convert types.
  * For detailed steps, see: {@link https://datatracker.ietf.org/doc/html/rfc8032#section-5.1.5}.
  * For example usage in a circuit, see: {@link https://github.com/semaphore-protocol/semaphore/blob/2c144fc9e55b30ad09474aeafa763c4115338409/packages/circuits/semaphore.circom#L21}
+ *
+ * The private key must be an instance of Buffer, Uint8Array or a string. The input will be used to
+ * generate entropy and there is no limit in size.
+ * The string is used as a set of raw bytes (in UTF-8) and is typically used to pass passwords or secret messages.
+ * If you want to pass a bigint, a number or a hexadecimal, be sure to convert them to one of the supported types first.
+ * The 'conversions' module in @zk-kit/utils provides a set of functions that may be useful in case you need to convert types.
+ *
  * @param privateKey The EdDSA private key for generating the associated public key.
  * @returns The derived secret scalar to be used to calculate public key and optimized for circuit calculations.
  */
@@ -56,10 +61,14 @@ export function deriveSecretScalar(privateKey: Buffer | Uint8Array | string): bi
  * {@link https://eips.ethereum.org/EIPS/eip-2494|Baby Jubjub} elliptic curve.
  * This function utilizes the Baby Jubjub elliptic curve for cryptographic operations.
  * The private key should be securely stored and managed, and it should never be exposed
- * The private key must be an instance of Buffer, Uint8Array or a string. If you want to pass a bigint, a number or a
- * hexadecimal, be sure to convert them to one of the supported types first. The 'conversions' module in @zk-kit/utils
- * provides a set of functions that may be useful in case you need to convert types.
  * or transmitted in an unsecured manner.
+ *
+ * The private key must be an instance of Buffer, Uint8Array or a string. The input will be used to
+ * generate entropy and there is no limit in size.
+ * The string is used as a set of raw bytes (in UTF-8) and is typically used to pass passwords or secret messages.
+ * If you want to pass a bigint, a number or a hexadecimal, be sure to convert them to one of the supported types first.
+ * The 'conversions' module in @zk-kit/utils provides a set of functions that may be useful in case you need to convert types.
+ *
  * @param privateKey The private key used for generating the public key.
  * @returns The derived public key.
  */
@@ -75,9 +84,13 @@ export function derivePublicKey(privateKey: Buffer | Uint8Array | string): Point
 /**
  * Signs a message using the provided private key, employing Poseidon hashing and
  * EdDSA with the Baby Jubjub elliptic curve.
- * The private key must be an instance of Buffer, Uint8Array or a string. If you want to pass a bigint, a number or a
- * hexadecimal, be sure to convert them to one of the supported types first. The 'conversions' module in @zk-kit/utils
- * provides a set of functions that may be useful in case you need to convert types.
+ *
+ * The private key must be an instance of Buffer, Uint8Array or a string. The input will be used to
+ * generate entropy and there is no limit in size.
+ * The string is used as a set of raw bytes (in UTF-8) and is typically used to pass passwords or secret messages.
+ * If you want to pass a bigint, a number or a hexadecimal, be sure to convert them to one of the supported types first.
+ * The 'conversions' module in @zk-kit/utils provides a set of functions that may be useful in case you need to convert types.
+ *
  * @param privateKey The private key used to sign the message.
  * @param message The message to be signed.
  * @returns The signature object, containing properties relevant to EdDSA signatures, such as 'R8' and 'S' values.
@@ -256,9 +269,13 @@ export class EdDSAPoseidon {
     /**
      * Initializes a new instance, deriving necessary cryptographic parameters from the provided private key.
      * If the private key is not passed as a parameter, a random 32-byte hexadecimal key is generated.
-     * The private key must be an instance of Buffer, Uint8Array or a string. If you want to pass a bigint, a number or a
-     * hexadecimal, be sure to convert them to one of the supported types first. The 'conversions' module in @zk-kit/utils
-     * provides a set of functions that may be useful in case you need to convert types.
+     *
+     * The private key must be an instance of Buffer, Uint8Array or a string. The input will be used to
+     * generate entropy and there is no limit in size.
+     * The string is used as a set of raw bytes (in UTF-8) and is typically used to pass passwords or secret messages.
+     * If you want to pass a bigint, a number or a hexadecimal, be sure to convert them to one of the supported types first.
+     * The 'conversions' module in @zk-kit/utils provides a set of functions that may be useful in case you need to convert types.
+     *
      * @param privateKey The private key used for signing and public key derivation.
      */
     constructor(privateKey: Buffer | Uint8Array | string = bufferToHexadecimal(crypto.getRandomValues(32))) {

--- a/packages/eddsa-poseidon/src/utils.ts
+++ b/packages/eddsa-poseidon/src/utils.ts
@@ -1,8 +1,8 @@
 import { Point } from "@zk-kit/baby-jubjub"
 import type { BigNumberish } from "@zk-kit/utils"
-import { bigNumberishToBigInt, bigNumberishToBuffer, bufferToBigInt } from "@zk-kit/utils/conversions"
+import { bigNumberishToBigInt, bufferToBigInt } from "@zk-kit/utils/conversions"
 import { requireTypes } from "@zk-kit/utils/error-handlers"
-import { isArray, isBigNumberish, isObject, isBigNumber } from "@zk-kit/utils/type-checks"
+import { isArray, isBigNumber, isBigNumberish, isObject } from "@zk-kit/utils/type-checks"
 import { Buffer } from "buffer"
 import { Blake512 } from "./blake"
 import { Signature } from "./types"
@@ -50,14 +50,10 @@ export function isSignature(signature: Signature): boolean {
  * @param privateKey The private key to check and convert.
  * @returns The private key as a Buffer.
  */
-export function checkPrivateKey(privateKey: BigNumberish): Buffer {
-    requireTypes(privateKey, "privateKey", ["bignumberish", "string"])
+export function checkPrivateKey(privateKey: Buffer | Uint8Array | string): Buffer {
+    requireTypes(privateKey, "privateKey", ["Buffer", "Uint8Array", "string"])
 
-    if (isBigNumberish(privateKey)) {
-        return bigNumberishToBuffer(privateKey)
-    }
-
-    return Buffer.from(privateKey as string)
+    return Buffer.from(privateKey)
 }
 
 /**

--- a/packages/eddsa-poseidon/tests/index.test.ts
+++ b/packages/eddsa-poseidon/tests/index.test.ts
@@ -41,18 +41,7 @@ describe("EdDSAPoseidon", () => {
         expect(publicKey[1]).toBe(circomlibPublicKey[1])
     })
 
-    it("Should derive a public key from a private key (hexadecimal)", async () => {
-        const privateKey = "0x12"
-
-        const publicKey = derivePublicKey(privateKey)
-
-        const circomlibPublicKey = eddsa.prv2pub(Buffer.from(privateKey.slice(2), "hex"))
-
-        expect(publicKey[0]).toBe(circomlibPublicKey[0])
-        expect(publicKey[1]).toBe(circomlibPublicKey[1])
-    })
-
-    it("Should derive a public key from a private key (buffer)", async () => {
+    it("Should derive a public key from a private key (Buffer)", async () => {
         const privateKey = Buffer.from("secret")
 
         const publicKey = derivePublicKey(privateKey)
@@ -63,34 +52,23 @@ describe("EdDSAPoseidon", () => {
         expect(publicKey[1]).toBe(circomlibPublicKey[1])
     })
 
-    it("Should derive a public key from a private key (bigint)", async () => {
-        const privateKey = BigInt(22)
+    it("Should derive a public key from a private key (Uint8Array)", async () => {
+        const privateKey = new Uint8Array([3, 2])
 
         const publicKey = derivePublicKey(privateKey)
 
-        const circomlibPublicKey = eddsa.prv2pub(Buffer.from(privateKey.toString(16), "hex"))
-
-        expect(publicKey[0]).toBe(circomlibPublicKey[0])
-        expect(publicKey[1]).toBe(circomlibPublicKey[1])
-    })
-
-    it("Should derive a public key from a private key (number)", async () => {
-        const privateKey = 22
-
-        const publicKey = derivePublicKey(privateKey)
-
-        const circomlibPublicKey = eddsa.prv2pub(Buffer.from(privateKey.toString(16), "hex"))
+        const circomlibPublicKey = eddsa.prv2pub(Buffer.from(privateKey))
 
         expect(publicKey[0]).toBe(circomlibPublicKey[0])
         expect(publicKey[1]).toBe(circomlibPublicKey[1])
     })
 
     it("Should throw an error if the secret type is not supported", async () => {
-        const privateKey = true
+        const privateKey = BigInt(32)
 
         const fun = () => derivePublicKey(privateKey as any)
 
-        expect(fun).toThrow(`Parameter 'privateKey' is none of the following types: bignumberish, string`)
+        expect(fun).toThrow(`Parameter 'privateKey' is none of the following types: Buffer, Uint8Array, string`)
     })
 
     it("Should sign a message (bigint)", async () => {
@@ -407,8 +385,8 @@ describe("EdDSAPoseidon", () => {
 
         const signature = eddsa.signMessage(message)
 
-        expect(eddsa.privateKey).toBeInstanceOf(Buffer)
-        expect(eddsa.privateKey).toHaveLength(32)
+        expect(typeof eddsa.privateKey).toBe("string")
+        expect(eddsa.privateKey).toHaveLength(64)
         expect(eddsa.secretScalar).toBe(deriveSecretScalar(eddsa.privateKey))
         expect(eddsa.packedPublicKey).toBe(packPublicKey(eddsa.publicKey))
         expect(eddsa.verifySignature(message, signature)).toBeTruthy()

--- a/packages/eddsa-proof/src/generate.ts
+++ b/packages/eddsa-proof/src/generate.ts
@@ -23,7 +23,7 @@ import { EddsaProof, SnarkArtifacts } from "./types"
  * @returns The Poseidon zero-knowledge proof.
  */
 export default async function generate(
-    privateKey: string | number | bigint | Buffer,
+    privateKey: Buffer | Uint8Array | string,
     scope: BytesLike | Hexable | number | bigint,
     snarkArtifacts?: SnarkArtifacts
 ): Promise<EddsaProof> {

--- a/packages/eddsa-proof/tests/index.test.ts
+++ b/packages/eddsa-proof/tests/index.test.ts
@@ -6,7 +6,7 @@ import { EddsaProof } from "../src/types"
 import verify from "../src/verify"
 
 describe("EddsaProof", () => {
-    const privateKey = 2
+    const privateKey = Buffer.from("secret")
     const scope = 1
 
     let fullProof: EddsaProof

--- a/packages/poseidon-cipher/tests/index.test.ts
+++ b/packages/poseidon-cipher/tests/index.test.ts
@@ -1,14 +1,13 @@
 import { derivePublicKey } from "@zk-kit/eddsa-poseidon"
-import { beBufferToBigInt, crypto } from "@zk-kit/utils"
+import { crypto } from "@zk-kit/utils"
 import { poseidonDecrypt, poseidonDecryptWithoutCheck, poseidonEncrypt } from "../src/poseidonCipher"
 import { Nonce, PlainText } from "../src/types"
 import { genEcdhSharedKey } from "./utils"
 
 describe("Poseidon Cipher", () => {
     const privateKey = crypto.getRandomValues(32)
-    const bgPrivateKey = beBufferToBigInt(Buffer.from(privateKey))
-    const publicKey = derivePublicKey(bgPrivateKey)
-    const encryptionKey = genEcdhSharedKey(bgPrivateKey, publicKey)
+    const publicKey = derivePublicKey(privateKey)
+    const encryptionKey = genEcdhSharedKey(privateKey, publicKey)
 
     const plainText: PlainText<bigint> = [BigInt(0), BigInt(1)]
     const nonce: Nonce = BigInt(5)

--- a/packages/poseidon-cipher/tests/utils.ts
+++ b/packages/poseidon-cipher/tests/utils.ts
@@ -11,7 +11,10 @@ import { EncryptionKey } from "../src/types"
  * @param pubKey A public key generated using genPubKey()
  * @returns The ECDH shared key.
  */
-export const genEcdhSharedKey = (privKey: bigint, pubKey: [bigint, bigint]): EncryptionKey<bigint> => {
+export const genEcdhSharedKey = (
+    privKey: Buffer | Uint8Array | string,
+    pubKey: [bigint, bigint]
+): EncryptionKey<bigint> => {
     const secretScalar = deriveSecretScalar(privKey)
 
     return mulPointEscalar(pubKey, secretScalar) as EncryptionKey<bigint>


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

Breaking change ⚠️ 

Types supported for the EdDSA private key have been reduced to 3: Buffer, Uint8Array, and string, i.e. buffers or text.

## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

Closes #188

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have run `yarn prettier` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] Any dependent changes have been merged and published in downstream modules
