### PR TITLE
Use `if` instead of `while` to increment depth in the `LeanIMT.insert` function

### DIFF
--- a/packages/imt.sol/contracts/internal/InternalLeanIMT.sol
+++ b/packages/imt.sol/contracts/internal/InternalLeanIMT.sol
@@ -46,6 +46,9 @@ library InternalLeanIMT {
             revert LeafAlreadyExists();
         }
 
+        // A new insertion can increase a tree's depth by at most 1,
+        // and only if the number of leaves supported by the current
+        // depth is less than the number of leaves to be supported after insertion.
         if (2 ** self.depth < self.size + 1) {
             self.depth += 1;
         }
@@ -103,6 +106,8 @@ library InternalLeanIMT {
         currentLevel = leaves;
 
         // Calculate the depth of the tree after adding the new values.
+        // Unlike the 'insert' function, we need a while here as
+        // N insertions can increase the tree's depth more than once.
         while (2 ** self.depth < self.size + leaves.length) {
             self.depth += 1;
         }

--- a/packages/imt.sol/contracts/internal/InternalLeanIMT.sol
+++ b/packages/imt.sol/contracts/internal/InternalLeanIMT.sol
@@ -46,7 +46,7 @@ library InternalLeanIMT {
             revert LeafAlreadyExists();
         }
 
-        while (2 ** self.depth < self.size + 1) {
+        if (2 ** self.depth < self.size + 1) {
             self.depth += 1;
         }
 


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

A new insertion can increase a tree's depth by at most 1. We can be sure that the while loop isn't executed twice.

## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

Closes #213

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have run `yarn prettier` and `yarn lint` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
