### PR TITLE
Remove merkle proof length check in the `update` function

### DIFF
--- a/packages/imt.sol/contracts/internal/InternalLeanIMT.sol
+++ b/packages/imt.sol/contracts/internal/InternalLeanIMT.sol
@@ -218,8 +218,6 @@ library InternalLeanIMT {
             revert LeafDoesNotExist();
         } else if (newLeaf != 0 && _has(self, newLeaf)) {
             revert LeafAlreadyExists();
-        } else if (siblingNodes.length == 0) {
-            revert WrongSiblingNodes();
         }
 
         uint256 index = _indexOf(self, oldLeaf);

--- a/packages/imt.sol/test/LeanIMT.ts
+++ b/packages/imt.sol/test/LeanIMT.ts
@@ -137,7 +137,7 @@ describe("LeanIMT", () => {
             await expect(transaction).to.be.revertedWithCustomError(leanIMT, "LeafGreaterThanSnarkScalarField")
         })
 
-        it("Should not update a leaf if there are no sibling nodes", async () => {
+        it("Should update a leaf if that's the only leaf in the tree", async () => {
             await leanIMTTest.insert(1)
 
             jsLeanIMT.insert(BigInt(1))
@@ -145,12 +145,14 @@ describe("LeanIMT", () => {
 
             const { siblings } = jsLeanIMT.generateProof(0)
 
-            const transaction = leanIMTTest.update(1, 2, siblings)
+            await leanIMTTest.update(1, 2, siblings)
 
-            await expect(transaction).to.be.revertedWithCustomError(leanIMT, "WrongSiblingNodes")
+            const root = await leanIMTTest.root()
+
+            expect(root).to.equal(jsLeanIMT.root)
         })
 
-        it("Should update a leaf", async () => {
+        it("Should update a leaf if there's more than 1 leaf in the tree", async () => {
             await leanIMTTest.insert(1)
             await leanIMTTest.insert(2)
 


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

Updating LeanIMT of size 1 (tree with 1 leaf inserted), the update function should not revert. This PR removes that check.

## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

Fixes #210

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have run `yarn prettier` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
