### PR TITLE
Update removed nodes

### DIFF
--- a/packages/imt.sol/contracts/internal/InternalLeanIMT.sol
+++ b/packages/imt.sol/contracts/internal/InternalLeanIMT.sol
@@ -236,7 +236,7 @@ library InternalLeanIMT {
             revert LeafGreaterThanSnarkScalarField();
         } else if (!_has(self, oldLeaf)) {
             revert LeafDoesNotExist();
-        } else if (newLeaf != 0 && _has(self, newLeaf)) {
+        } else if (_has(self, newLeaf)) {
             revert LeafAlreadyExists();
         }
 

--- a/packages/imt.sol/contracts/internal/InternalLeanIMT.sol
+++ b/packages/imt.sol/contracts/internal/InternalLeanIMT.sol
@@ -234,8 +234,6 @@ library InternalLeanIMT {
     ) internal returns (uint256) {
         if (newLeaf >= SNARK_SCALAR_FIELD) {
             revert LeafGreaterThanSnarkScalarField();
-        } else if (oldLeaf == 0) {
-            revert LeafCannotBeZero();
         } else if (!_has(self, oldLeaf)) {
             revert LeafDoesNotExist();
         } else if (newLeaf != 0 && _has(self, newLeaf)) {
@@ -291,7 +289,11 @@ library InternalLeanIMT {
         }
 
         self.sideNodes[treeDepth] = node;
-        self.leaves[newLeaf] = self.leaves[oldLeaf];
+
+        if (newLeaf != 0) {
+            self.leaves[newLeaf] = self.leaves[oldLeaf];
+        }
+
         self.leaves[oldLeaf] = 0;
 
         return node;

--- a/packages/imt.sol/contracts/internal/InternalLeanIMT.sol
+++ b/packages/imt.sol/contracts/internal/InternalLeanIMT.sol
@@ -234,6 +234,8 @@ library InternalLeanIMT {
     ) internal returns (uint256) {
         if (newLeaf >= SNARK_SCALAR_FIELD) {
             revert LeafGreaterThanSnarkScalarField();
+        } else if (oldLeaf == 0) {
+            revert LeafCannotBeZero();
         } else if (!_has(self, oldLeaf)) {
             revert LeafDoesNotExist();
         } else if (newLeaf != 0 && _has(self, newLeaf)) {

--- a/packages/imt.sol/test/LeanIMT.ts
+++ b/packages/imt.sol/test/LeanIMT.ts
@@ -322,6 +322,21 @@ describe("LeanIMT", () => {
 
             expect(hasLeaf).to.equal(false)
         })
+
+        it("Should return false if the leaf is 0", async () => {
+            await leanIMTTest.insertMany([1, 2])
+            jsLeanIMT.insertMany([BigInt(1), BigInt(2)])
+
+            jsLeanIMT.update(1, BigInt(0))
+
+            const { siblings } = jsLeanIMT.generateProof(1)
+
+            await leanIMTTest.remove(2, siblings)
+
+            const hasLeaf = await leanIMTTest.has(0)
+
+            expect(hasLeaf).to.equal(false)
+        })
     })
     describe("# indexOf", () => {
         it("Should return the index of a leaf", async () => {

--- a/packages/imt.sol/test/LeanIMT.ts
+++ b/packages/imt.sol/test/LeanIMT.ts
@@ -219,6 +219,25 @@ describe("LeanIMT", () => {
                 expect(root).to.equal(jsLeanIMT.root)
             }
         })
+
+        it("Should not update a leaf that was removed", async () => {
+            await leanIMTTest.insertMany([1, 2])
+            jsLeanIMT.insertMany([BigInt(1), BigInt(2)])
+
+            jsLeanIMT.update(1, BigInt(0))
+
+            const { siblings } = jsLeanIMT.generateProof(1)
+
+            await leanIMTTest.remove(2, siblings)
+
+            jsLeanIMT.update(1, BigInt(3))
+
+            const { siblings: newSiblings } = jsLeanIMT.generateProof(1)
+
+            const transaction = leanIMTTest.update(0, 3, newSiblings)
+
+            await expect(transaction).to.be.revertedWithCustomError(leanIMT, "LeafCannotBeZero")
+        })
     })
 
     describe("# remove", () => {

--- a/packages/imt.sol/test/LeanIMT.ts
+++ b/packages/imt.sol/test/LeanIMT.ts
@@ -252,7 +252,7 @@ describe("LeanIMT", () => {
 
             const transaction = leanIMTTest.update(0, 3, newSiblings)
 
-            await expect(transaction).to.be.revertedWithCustomError(leanIMT, "LeafCannotBeZero")
+            await expect(transaction).to.be.revertedWithCustomError(leanIMT, "LeafDoesNotExist")
         })
         it("Should not update a leaf if the new value already exists", async () => {
             await leanIMTTest.insert(1)


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

This PR:

- Adds a check to the `_update` function in the `InternalLeanIMT.sol` file to update the `newLeaf` index only if `newLeaf` is different from 0. Now when trying to update a removed leaf the transaction will revert with the custom error `LeafDoesNotExist`. 

- Removes unnecessary `newLeaf != 0` check. Since the _has function will no longer return true for the leaf 0, this check is no longer
necessary.

- Adds new tests to cover 100% of the lines of `InternalLeanIMT.sol`,

## Related Issue(s)

Closes #228

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have run `yarn prettier` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] Any dependent changes have been merged and published in downstream modules
