### PR TITLE
ci(docs): download artifacts to static assets folders

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,12 @@ jobs:
             - name: Generate doc website
               run: yarn docs
 
+            - name: Download artifacts
+              run: bash <(curl -sSL "https://raw.githubusercontent.com/privacy-scaling-explorations/snark-artifacts/main/dowload-artifacts")
+
+            - name: Move artifacts to build directory
+              run: mkdir -p docs/assets/artifacts && mv *.{wasm,zkey} docs/assets/artifacts
+
             - name: Publish on Github Pages
               uses: crazy-max/ghaction-github-pages@v2.5.0
               with:


### PR DESCRIPTION
## Description
#240 aims at moving the functions to download/get snark artifacts (semaphore, poseidon, edDSA) to the utils package.
One challenge is that these artifacts are now hosted on different servers (semaphore.cedoor.dev and zkkit.cedoor.dev) at slightly different paths.

After pushing all the artifacts to https://github.com/privacy-scaling-explorations/snark-artifacts (instead of bloating zk-kit repo), this PR suggests a solution to have them also available at https://zkkit.pse.dev/assets/artifacts.
https://zkkit.pse.dev/assets/artifacts would then become the default artifact host url for all artifacts in zk-kit.

## Related Issue(s)
#176


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
<!-- Feel free to remove this section if you will not use it. -->

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] ~~I have commented my code, particularly in hard-to-understand areas~~
-   [x] ~~I have made corresponding changes to the documentation~~
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [x] ~~I have added tests that prove my fix is effective or that my feature works~~
-   [x] New and existing unit tests pass locally with my changes
-   [x] Any dependent changes have been merged and published in downstream modules
