### PR TITLE
refactor(utils): update F1Field.e(res) function to remove the comparison checks with this._order

### DIFF
--- a/packages/utils/src/f1-field.ts
+++ b/packages/utils/src/f1-field.ts
@@ -35,17 +35,8 @@ export default class F1Field {
      * @returns The equivalent value within the field.
      */
     e(res: bigint): bigint {
-        if (res < 0) {
-            let nres = -res
-
-            if (nres >= this._order) {
-                nres %= this._order
-            }
-
-            return this._order - nres
-        }
-
-        return res >= this._order ? res % this._order : res
+        res %= this._order
+        return res < 0 ? res + this._order : res
     }
 
     /**


### PR DESCRIPTION
F1Field.e(res) checks if it is >= this._order to determine if it needs to take a modulus with this._order. However, in v8 bigint implementation, this check is already present. So this check is not necessary as bigint implementation already does that. This commit removes these checks.

https://github.com/v8/v8/blob/497d8573dc80b1b69052a834bec894cf5d4238e7/src/builtins/builtins-bigint.tq#L380-L383

I was just reading zk-kit's F1Field code after studying modular arithmetic. Please let me know if this is useful!

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
