### PR TITLE
fix(github actions): pin noir version to 0.26.0

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -53,7 +53,7 @@ jobs:
             - name: Install Nargo
               uses: noir-lang/noirup@v0.1.3
               with:
-                  toolchain: nightly
+                  toolchain: 0.26.0
 
             - name: Install dependencies
               run: yarn

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -46,7 +46,7 @@ jobs:
             - name: Install Nargo
               uses: noir-lang/noirup@v0.1.3
               with:
-                  toolchain: nightly
+                  toolchain: 0.26.0
 
             - name: Install dependencies
               run: yarn


### PR DESCRIPTION
Pins Noir version in github actions to 0.26.0, this ensures Noir tests won't fail randomly (famous last words...)