### PR TITLE
Add mod reduction in secret scalar generation

### DIFF
--- a/packages/eddsa-poseidon/src/eddsa-poseidon.ts
+++ b/packages/eddsa-poseidon/src/eddsa-poseidon.ts
@@ -53,7 +53,7 @@ export function deriveSecretScalar(privateKey: Buffer | Uint8Array | string): bi
     hash = hash.slice(0, 32)
     hash = pruneBuffer(hash)
 
-    return scalar.shiftRight(leBufferToBigInt(hash), BigInt(3))
+    return scalar.shiftRight(leBufferToBigInt(hash), BigInt(3)) % subOrder
 }
 
 /**


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

The secret scalar is used to derive the public key and it must be > l, where l is the sub-order used in Baby Jubjub. Adding a mod reduction ensures it always stays in the right range by keeping it compatible with the existing public keys.

## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

Fixes #239

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
