### PR TITLE
docs: fix `typedoc` compilation warnings

### DIFF
--- a/packages/eddsa-poseidon/src/eddsa-poseidon.ts
+++ b/packages/eddsa-poseidon/src/eddsa-poseidon.ts
@@ -228,7 +228,7 @@ export function packSignature(signature: Signature): Buffer {
 }
 
 /**
- * Unpacks a signature produced by {@link #packSignature}.  See that function
+ * Unpacks a signature produced by {@link packSignature}.  See that function
  * for the details of the format.
  *
  * @param packedSignature the 64 byte buffer to unpack

--- a/packages/lazytower/src/lazytower-hash-chain-proof-builder.ts
+++ b/packages/lazytower/src/lazytower-hash-chain-proof-builder.ts
@@ -94,7 +94,7 @@ export function LazyTowerHashChainProofBuilder(H: number, W: number, hash = defa
     }
     /**
      * Builds a proof of membership.
-     * @param index Index of the proof's item.
+     * @param idx Index of the proof's item.
      * @returns Proof object.
      */
     function build(idx: number): LazyTowerHashChainProof {

--- a/packages/poseidon-proof/src/verify.ts
+++ b/packages/poseidon-proof/src/verify.ts
@@ -6,7 +6,8 @@ import verificationKeys from "./verification-keys.json"
 
 /**
  * Verifies that a Poseidon proof is valid.
- * @param poseidonProof The Poseidon zero-knowledge proof.
+ * @param numberOfInputs The number of inputs supported by the Poseidon hash function.
+ * @param proof PoseidonProof
  * @returns True if the proof is valid, false otherwise.
  */
 export default function verify(numberOfInputs: number, { scope, digest, proof }: PoseidonProof): Promise<boolean> {

--- a/packages/smt/src/smt.ts
+++ b/packages/smt/src/smt.ts
@@ -357,7 +357,6 @@ export default class SMT {
      * @param node The node to start from.
      * @param path The path of the key.
      * @param siblings The siblings of the path.
-     * @param i The index to start from.
      */
     private deleteOldNodes(node: Node, path: number[], siblings: Siblings) {
         for (let i = siblings.length - 1; i >= 0; i -= 1) {

--- a/packages/utils/src/type-checks.ts
+++ b/packages/utils/src/type-checks.ts
@@ -9,8 +9,8 @@
 
 import { Buffer } from "buffer"
 
-// The list of types supported by this utility functions.
-const supportedTypes = [
+/** @internal */
+export const supportedTypes = [
     "number",
     "string",
     "function",
@@ -25,7 +25,6 @@ const supportedTypes = [
     "bignumberish"
 ] as const
 
-// Type extracted from the list above.
 export type SupportedType = (typeof supportedTypes)[number]
 
 /**
@@ -173,6 +172,7 @@ export function isBigNumberish(value: any): boolean {
 /**
  * Returns true if the value type is the same as the type passed
  * as the second parameter, false otherwise.
+ * @param value
  * @param type The expected type.
  */
 export function isType(value: any, type: SupportedType): boolean {

--- a/typedoc.js
+++ b/typedoc.js
@@ -1,0 +1,16 @@
+const fs = require("fs")
+const path = require("path")
+
+const EXCLUDE_PKGS = ["circuits", "lazytower.circom", "lazytower.sol", "imt.sol", "rollup-plugin-rust"]
+const packagesDir = path.join(__dirname, "packages")
+const entryPoints = fs
+    .readdirSync(packagesDir, { withFileTypes: true })
+    .filter((dirent) => dirent.isDirectory() && !EXCLUDE_PKGS.includes(dirent.name))
+    .map((dirent) => path.join("packages", dirent.name))
+
+/** @type {import('typedoc').typedocoptions} */
+module.exports = {
+    entryPoints,
+    name: "zk-kit",
+    entryPointStrategy: "packages"
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,6 +1,0 @@
-{
-    "entryPoints": ["packages/*"],
-    "name": "ZK-kit",
-    "entryPointStrategy": "packages",
-    "exclude": ["**/*.sol", "**/*.circom", "**/rollup-plugin-rust"]
-}


### PR DESCRIPTION
Fix different warnings shown when building the docs.

Fixes #258

## Test plan
|Before|After|
|--|--|
|`yarn docs`: builds successfully but generates a bunch of warnings|`yarn docs`: builds successfully without warnings|