### PR TITLE
chore: increase timeout test

### DIFF
--- a/packages/imt.sol/test/LazyIMT.ts
+++ b/packages/imt.sol/test/LazyIMT.ts
@@ -355,7 +355,7 @@ describe("LazyIMT", () => {
                     await network.provider.request({ method: "evm_revert", params: [snapshoot] })
                 }
             }
-        }).timeout(6 * 60 * 1000)
+        }).timeout(8 * 60 * 1000)
     })
 
     it("Should fail to generate out of range static root", async () => {

--- a/packages/imt.sol/test/LazyIMT.ts
+++ b/packages/imt.sol/test/LazyIMT.ts
@@ -355,7 +355,7 @@ describe("LazyIMT", () => {
                     await network.provider.request({ method: "evm_revert", params: [snapshoot] })
                 }
             }
-        }).timeout(5 * 60 * 1000)
+        }).timeout(6 * 60 * 1000)
     })
 
     it("Should fail to generate out of range static root", async () => {


### PR DESCRIPTION

## Description
* Increases timeout of `Should produce valid Merke proofs for different trees` test from `5minutes` to `6minutes` to fix [intermittent timeouts](https://github.com/privacy-scaling-explorations/zk-kit/commit/0699fd1e5ad3683ae0090e0626f75d7834145500#r141218878).