### PR TITLE
ci: split tests in multiple concurrent jobs in pr workflow

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -61,7 +61,7 @@ jobs:
             - name: Build libraries and contracts
               run: yarn build
 
-            - name: Test libraries, contracts and circuits
+            - name: Test ${{ matrix.type }}
               run: yarn test:${{ matrix.type }}
 
             - name: Coveralls

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -25,6 +25,12 @@ jobs:
 
     test:
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                type:
+                    - circuits
+                    - contracts
+                    - libraries
 
         steps:
             - name: Checkout
@@ -51,6 +57,8 @@ jobs:
             - name: Install dependencies
               run: yarn
 
-            # test script runs turbo tasks that dependsOn build, so build will be taken care of automatically
-            - name: Test libraries, contracts and circuits
-              run: yarn test
+            - name: Build libraries and contracts
+              run: yarn build
+
+            - name: Test ${{ matrix.type }}
+              run: yarn test:${{ matrix.type }}


### PR DESCRIPTION
Fix #263 so that it is easier to read the workflow logs and see which tests group may be failing. (Current failing `test:contracts` job needs #262 to succeed)

It does not seem to have any impact all the timeout issues we experienced latest in some tests (see #240 or #262).  

|Before|After|
|---|---|
|![image](https://github.com/privacy-scaling-explorations/zk-kit/assets/38692952/e417f566-68e4-4f4d-a2ad-dd2361b6d840)|![image](https://github.com/privacy-scaling-explorations/zk-kit/assets/38692952/629087be-b582-4a99-9d98-f904304534ce)|