### PR TITLE
refactor!: change types for scope parameter

### DIFF
--- a/packages/eddsa-proof/README.md
+++ b/packages/eddsa-proof/README.md
@@ -74,9 +74,9 @@ yarn add @zk-kit/eddsa-proof
 import { generate, verify } from "@zk-kit/eddsa-proof"
 
 // Your private key (secret) associated with your commitment.
-const privateKey = 1
+const privateKey = "secret"
 // A public value used to contextualize the cryptographic proof and calculate the nullifier.
-const scope = 2
+const scope = "scope"
 
 // Generate the proof.
 const fullProof = await generate(privateKey, scope)
@@ -84,19 +84,20 @@ const fullProof = await generate(privateKey, scope)
 /*
     nb. commitment and scope are always the same - proof is variable.
 {
-    commitment: '5049599877119858813001062015237093339640938925333103011635461484168047396248',
-    scope: '2',
+    commitment: '21756852044673293804725356853298692762259855200429755225624171532449447776732',
+    scope: '52191664570483756643537362991541193331102618014473399276861326740461293928448',
     proof: [
-        '8187226249860430947135181878676566080058748127595453962723730464659559265736',
-        '8666342086907686904498490524943571067960174826127841344605359274053291451578',
-        '16951173581335355551706227874569504050650723200983520067525262527574411463239',
-        '5330430283785726456850074841877892816784859299864106837646103067998557420540',
-        '4275240916243995687770977511669101428890222781102049409716491642577511403456',
-        '5254784175927576727963123852365247945765593646193022684829294352292688366957',
-        '1691932310118878640744410451232696949890002258184298580387126997072583471834',
-        '18016798021948724211946223868702828962374378289486618942397810491195719212700'
+        '14987543977537638797613616391807211498102534775759297152458980015937921301475',
+        '3399335485250714998192957632691923175498432819155620830553382340417897595836',
+        '458847933923791518779258584891719351511628278818450523853640641455008133942',
+        '9130558865745328382423837376229933835283742789420937388990076948167771186665',
+        '2527867303822223913583586720705858457538165210401589969189198821632271648294',
+        '870032122185130505849909299495220614500026484724112145131565329210361970548',
+        '7499124546917660821334566902083675362480525785493429715971012094306224236446',
+        '4681140599918274218600441523225984097742730174371377925026448119492671129895'
     ]
 }
+
 */
 console.log(fullProof)
 
@@ -104,8 +105,8 @@ console.log(fullProof)
 // You can specify them as follows.
 
 // const fullProof = await generate(privateKey, scope, {
-//     wasmFilePath: "<your-path>/eddsa-proof.wasm",
-//     zkeyFilePath: "<your-path>/eddsa-proof.zkey"
+//     wasm: "<your-path>/eddsa-proof.wasm",
+//     zkey: "<your-path>/eddsa-proof.zkey"
 // })
 
 // Verify the proof.
@@ -117,21 +118,18 @@ console.log(response)
 
 ## 📈 Benchmarks
 
-Benchmarks were run on a MacBook Pro, Apple M2 Pro, 16 GB RAM machine, after initializing the BN128 curve with [`@zk-kit/groth16`](https://github.com/privacy-scaling-explorations/zk-kit/edit/main/packages/groth16)-`buildBn128` (~230ms).
+Benchmarks were run on an Intel Core i7-1165G7, 16 GB RAM machine.
 
 | Generate proof | Verify proof | Constraints |
 | -------------- | ------------ | ----------- |
-| `528.91 ms`    | `10. 997ms`  | `1017`      |
+| `258ms`        | `15ms`       | `1017`      |
 
 ```ts
 import { generate, verify } from "@zk-kit/eddsa-proof"
-import { buildBn128 } from "@zk-kit/groth16"
-
-await buildBn128()
 
 console.time("generate")
 
-const proof = await generate(1, 2)
+const proof = await generate("secret", "scope")
 
 console.timeEnd("generate")
 

--- a/packages/eddsa-proof/package.json
+++ b/packages/eddsa-proof/package.json
@@ -44,11 +44,9 @@
         "rollup-plugin-cleanup": "^3.2.1"
     },
     "dependencies": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
         "@zk-kit/eddsa-poseidon": "1.0.0-beta",
         "@zk-kit/utils": "1.0.0-beta.4",
+        "ethers": "^6.12.0",
         "snarkjs": "^0.7.3"
     }
 }

--- a/packages/eddsa-proof/src/generate.ts
+++ b/packages/eddsa-proof/src/generate.ts
@@ -1,9 +1,9 @@
-import { BigNumber } from "@ethersproject/bignumber"
-import { BytesLike, Hexable } from "@ethersproject/bytes"
 import { deriveSecretScalar } from "@zk-kit/eddsa-poseidon"
+import { SnarkArtifacts, maybeGetEdDSASnarkArtifacts, packGroth16Proof } from "@zk-kit/utils"
+import type { BigNumberish } from "ethers"
 import { NumericString, groth16 } from "snarkjs"
-import { packGroth16Proof, maybeGetEdDSASnarkArtifacts, SnarkArtifacts } from "@zk-kit/utils"
 import hash from "./hash"
+import toBigInt from "./to-bigint"
 import { EddsaProof } from "./types"
 
 /**
@@ -23,9 +23,11 @@ import { EddsaProof } from "./types"
  */
 export default async function generate(
     privateKey: Buffer | Uint8Array | string,
-    scope: BytesLike | Hexable | number | bigint,
+    scope: BigNumberish | Uint8Array | string,
     snarkArtifacts?: SnarkArtifacts
 ): Promise<EddsaProof> {
+    scope = toBigInt(scope)
+
     // allow user to override our artifacts
     // otherwise they'll be downloaded if not already in local tmp folder
     snarkArtifacts ??= await maybeGetEdDSASnarkArtifacts()
@@ -43,7 +45,7 @@ export default async function generate(
 
     return {
         commitment: publicSignals[0],
-        scope: BigNumber.from(scope).toString() as NumericString,
+        scope: scope.toString() as NumericString,
         proof: packGroth16Proof(proof)
     }
 }

--- a/packages/eddsa-proof/src/hash.ts
+++ b/packages/eddsa-proof/src/hash.ts
@@ -1,6 +1,6 @@
-import { BigNumber } from "@ethersproject/bignumber"
-import { BytesLike, Hexable, zeroPad } from "@ethersproject/bytes"
-import { keccak256 } from "@ethersproject/keccak256"
+import type { BigNumberish } from "ethers"
+import { keccak256 } from "ethers/crypto"
+import { toBeHex } from "ethers/utils"
 import { NumericString } from "snarkjs"
 
 /**
@@ -8,9 +8,6 @@ import { NumericString } from "snarkjs"
  * @param message The message to be hashed.
  * @returns The message digest.
  */
-export default function hash(message: BytesLike | Hexable | number | bigint): NumericString {
-    message = BigNumber.from(message).toTwos(256).toHexString()
-    message = zeroPad(message, 32)
-
-    return (BigInt(keccak256(message)) >> BigInt(8)).toString() as NumericString
+export default function hash(message: BigNumberish): NumericString {
+    return (BigInt(keccak256(toBeHex(message, 32))) >> BigInt(8)).toString()
 }

--- a/packages/eddsa-proof/src/to-bigint.ts
+++ b/packages/eddsa-proof/src/to-bigint.ts
@@ -1,0 +1,20 @@
+import type { BigNumberish } from "ethers"
+import { encodeBytes32String } from "ethers/abi"
+import { toBigInt as _toBigInt } from "ethers/utils"
+
+/**
+ * Converts a bignumberish or a text to a bigint.
+ * @param value The value to be converted to bigint.
+ * @return The value converted to bigint.
+ */
+export default function toBigInt(value: BigNumberish | Uint8Array | string): bigint {
+    try {
+        return _toBigInt(value)
+    } catch (error: any) {
+        if (typeof value === "string") {
+            return _toBigInt(encodeBytes32String(value))
+        }
+
+        throw TypeError(error.message)
+    }
+}

--- a/packages/eddsa-proof/tests/index.test.ts
+++ b/packages/eddsa-proof/tests/index.test.ts
@@ -1,13 +1,14 @@
-import { buildBn128 } from "@zk-kit/groth16"
-import { poseidon2 } from "poseidon-lite"
 import { derivePublicKey } from "@zk-kit/eddsa-poseidon"
+import { buildBn128 } from "@zk-kit/groth16"
+import { decodeBytes32String, toBeHex } from "ethers"
+import { poseidon2 } from "poseidon-lite"
 import generate from "../src/generate"
 import { EddsaProof } from "../src/types"
 import verify from "../src/verify"
 
 describe("EddsaProof", () => {
     const privateKey = Buffer.from("secret")
-    const scope = 1
+    const scope = "scope"
 
     let fullProof: EddsaProof
     let curve: any
@@ -28,7 +29,7 @@ describe("EddsaProof", () => {
             const commitment = poseidon2(publicKey)
 
             expect(fullProof.proof).toHaveLength(8)
-            expect(fullProof.scope).toBe(scope.toString())
+            expect(decodeBytes32String(toBeHex(fullProof.scope, 32))).toBe(scope.toString())
             expect(fullProof.commitment).toBe(commitment.toString())
         })
     })

--- a/packages/poseidon-proof/README.md
+++ b/packages/poseidon-proof/README.md
@@ -79,12 +79,12 @@ yarn add @zk-kit/poseidon-proof
 import { generate, verify } from "@zk-kit/poseidon-proof"
 
 // A public value used to contextualize the cryptographic proof and calculate the nullifier.
-const scope = 1
+const scope = "scope"
 // The message (preimage) to prove (secret).
-const message = 2
+const messages = [1, 2]
 
 // Generate the proof.
-const fullProof = await generate(message, scope)
+const fullProof = await generate(messages, scope)
 
 /*
     nb. scope, digest and nullifier are always the same - proof is variable.
@@ -110,8 +110,8 @@ console.log(fullProof)
 // You can specify them as follows.
 
 // const fullProof = await generate(message, scope, {
-//     wasmFilePath: "<your-path>/poseidon-proof.wasm",
-//     zkeyFilePath: "<your-path>/poseidon-proof.zkey"
+//     wasm: "<your-path>/poseidon-proof.wasm",
+//     zkey: "<your-path>/poseidon-proof.zkey"
 // })
 
 // Verify the proof.
@@ -125,21 +125,18 @@ console.log(response)
 
 ## 📈 Benchmarks
 
-Benchmarks were run on an Intel Core i7-1165G7, 16 GB RAM machine, after initializing the BN128 curve with [`@zk-kit/groth16`](https://github.com/privacy-scaling-explorations/zk-kit/edit/main/packages/groth16)-`buildBn128` (~230ms).
+Benchmarks were run on an Intel Core i7-1165G7, 16 GB RAM machine (with two inputs).
 
 | Generate proof | Verify proof | Constraints |
 | -------------- | ------------ | ----------- |
-| `80ms`         | `10ms`       | `141`       |
+| `170ms`         | `12ms`       | `214`       |
 
 ```js
 import { generate, verify } from "@zk-kit/poseidon-proof"
-import { buildBn128 } from "@zk-kit/groth16"
-
-await buildBn128()
 
 console.time("generate")
 
-const proof = await generate(1, 2)
+const proof = await generate([1, 2], "scope")
 
 console.timeEnd("generate")
 

--- a/packages/poseidon-proof/README.md
+++ b/packages/poseidon-proof/README.md
@@ -129,7 +129,7 @@ Benchmarks were run on an Intel Core i7-1165G7, 16 GB RAM machine (with two inpu
 
 | Generate proof | Verify proof | Constraints |
 | -------------- | ------------ | ----------- |
-| `170ms`         | `12ms`       | `214`       |
+| `170ms`        | `12ms`       | `214`       |
 
 ```js
 import { generate, verify } from "@zk-kit/poseidon-proof"

--- a/packages/poseidon-proof/package.json
+++ b/packages/poseidon-proof/package.json
@@ -44,10 +44,8 @@
         "rollup-plugin-cleanup": "^3.2.1"
     },
     "dependencies": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
         "@zk-kit/utils": "1.0.0-beta.4",
+        "ethers": "^6.12.0",
         "snarkjs": "^0.7.3"
     }
 }

--- a/packages/poseidon-proof/src/generate.ts
+++ b/packages/poseidon-proof/src/generate.ts
@@ -1,8 +1,9 @@
 import { BigNumber } from "@ethersproject/bignumber"
-import { BytesLike, Hexable } from "@ethersproject/bytes"
+import { SnarkArtifacts, maybeGetPoseidonSnarkArtifacts, packGroth16Proof } from "@zk-kit/utils"
+import { BigNumberish } from "ethers"
 import { NumericString, groth16 } from "snarkjs"
-import { packGroth16Proof, maybeGetPoseidonSnarkArtifacts, SnarkArtifacts } from "@zk-kit/utils"
 import hash from "./hash"
+import toBigInt from "./to-bigint"
 import { PoseidonProof } from "./types"
 
 /**
@@ -21,10 +22,12 @@ import { PoseidonProof } from "./types"
  * @returns The Poseidon zero-knowledge proof.
  */
 export default async function generate(
-    preimages: Array<BytesLike | Hexable | number | bigint>,
-    scope: BytesLike | Hexable | number | bigint,
+    preimages: Array<BigNumberish>,
+    scope: BigNumberish | Uint8Array | string,
     snarkArtifacts?: SnarkArtifacts
 ): Promise<PoseidonProof> {
+    scope = toBigInt(scope)
+
     // allow user to override our artifacts
     // otherwise they'll be downloaded if not already in local tmp folder
     snarkArtifacts ??= await maybeGetPoseidonSnarkArtifacts(preimages.length)
@@ -40,6 +43,7 @@ export default async function generate(
     )
 
     return {
+        numberOfInputs: preimages.length,
         scope: BigNumber.from(scope).toString() as NumericString,
         digest: publicSignals[0],
         proof: packGroth16Proof(proof)

--- a/packages/poseidon-proof/src/hash.ts
+++ b/packages/poseidon-proof/src/hash.ts
@@ -1,6 +1,6 @@
-import { BigNumber } from "@ethersproject/bignumber"
-import { BytesLike, Hexable, zeroPad } from "@ethersproject/bytes"
-import { keccak256 } from "@ethersproject/keccak256"
+import type { BigNumberish } from "ethers"
+import { keccak256 } from "ethers/crypto"
+import { toBeHex } from "ethers/utils"
 import { NumericString } from "snarkjs"
 
 /**
@@ -8,9 +8,6 @@ import { NumericString } from "snarkjs"
  * @param message The message to be hashed.
  * @returns The message digest.
  */
-export default function hash(message: BytesLike | Hexable | number | bigint): NumericString {
-    message = BigNumber.from(message).toTwos(256).toHexString()
-    message = zeroPad(message, 32)
-
-    return (BigInt(keccak256(message)) >> BigInt(8)).toString() as NumericString
+export default function hash(message: BigNumberish): NumericString {
+    return (BigInt(keccak256(toBeHex(message, 32))) >> BigInt(8)).toString()
 }

--- a/packages/poseidon-proof/src/to-bigint.ts
+++ b/packages/poseidon-proof/src/to-bigint.ts
@@ -1,0 +1,20 @@
+import type { BigNumberish } from "ethers"
+import { encodeBytes32String } from "ethers/abi"
+import { toBigInt as _toBigInt } from "ethers/utils"
+
+/**
+ * Converts a bignumberish or a text to a bigint.
+ * @param value The value to be converted to bigint.
+ * @return The value converted to bigint.
+ */
+export default function toBigInt(value: BigNumberish | Uint8Array | string): bigint {
+    try {
+        return _toBigInt(value)
+    } catch (error: any) {
+        if (typeof value === "string") {
+            return _toBigInt(encodeBytes32String(value))
+        }
+
+        throw TypeError(error.message)
+    }
+}

--- a/packages/poseidon-proof/src/types/index.ts
+++ b/packages/poseidon-proof/src/types/index.ts
@@ -2,6 +2,7 @@ import { NumericString } from "snarkjs"
 import { PackedGroth16Proof } from "@zk-kit/utils"
 
 export type PoseidonProof = {
+    numberOfInputs: number
     scope: NumericString
     digest: NumericString
     proof: PackedGroth16Proof

--- a/packages/poseidon-proof/src/verify.ts
+++ b/packages/poseidon-proof/src/verify.ts
@@ -6,11 +6,10 @@ import verificationKeys from "./verification-keys.json"
 
 /**
  * Verifies that a Poseidon proof is valid.
- * @param numberOfInputs The number of inputs supported by the Poseidon hash function.
  * @param proof PoseidonProof
  * @returns True if the proof is valid, false otherwise.
  */
-export default function verify(numberOfInputs: number, { scope, digest, proof }: PoseidonProof): Promise<boolean> {
+export default function verify({ numberOfInputs, scope, digest, proof }: PoseidonProof): Promise<boolean> {
     const verificationKey = {
         ...verificationKeys,
         vk_delta_2: verificationKeys.vk_delta_2[numberOfInputs - 1],

--- a/packages/poseidon-proof/tests/index.test.ts
+++ b/packages/poseidon-proof/tests/index.test.ts
@@ -1,6 +1,14 @@
 import { buildBn128 } from "@zk-kit/groth16"
+import { decodeBytes32String, toBeHex } from "ethers"
 import {
     poseidon1,
+    poseidon10,
+    poseidon11,
+    poseidon12,
+    poseidon13,
+    poseidon14,
+    poseidon15,
+    poseidon16,
     poseidon2,
     poseidon3,
     poseidon4,
@@ -8,19 +16,12 @@ import {
     poseidon6,
     poseidon7,
     poseidon8,
-    poseidon9,
-    poseidon10,
-    poseidon11,
-    poseidon12,
-    poseidon13,
-    poseidon14,
-    poseidon15,
-    poseidon16
+    poseidon9
 } from "poseidon-lite"
 import generate from "../src/generate"
+import hash from "../src/hash"
 import { PoseidonProof } from "../src/types"
 import verify from "../src/verify"
-import hash from "../src/hash"
 
 const poseidonFunctions = [
     poseidon1,
@@ -44,7 +45,7 @@ const poseidonFunctions = [
 const computePoseidon = (preimages: string[]) => poseidonFunctions[preimages.length - 1](preimages)
 
 const preimages = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
-const scope = 1
+const scope = "scope"
 let curve: any
 const proofs: Array<{ fullProof: PoseidonProof; digest: bigint }> = []
 
@@ -66,14 +67,14 @@ describe("PoseidonProof", () => {
     it("should generate a Poseidon proof from 1 to 16 preimages", async () => {
         for (const { fullProof, digest } of proofs) {
             expect(fullProof.proof).toHaveLength(8)
-            expect(fullProof.scope).toBe(scope.toString())
+            expect(decodeBytes32String(toBeHex(fullProof.scope, 32))).toBe(scope.toString())
             expect(fullProof.digest).toBe(digest.toString())
         }
     })
 
     it("Should verify a Poseidon proof from 1 to 16 preimage(s)", async () => {
-        proofs.forEach(async ({ fullProof }, i) => {
-            await expect(verify(i + 1, fullProof)).resolves.toBe(true)
+        proofs.forEach(async ({ fullProof }) => {
+            await expect(verify(fullProof)).resolves.toBe(true)
         })
     })
 
@@ -81,7 +82,7 @@ describe("PoseidonProof", () => {
         const { fullProof } = proofs[0]
         fullProof.digest = "3"
 
-        const response = await verify(preimages.length, fullProof)
+        const response = await verify(fullProof)
 
         expect(response).toBe(false)
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3573,9 +3573,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@zk-kit/eddsa-proof@workspace:packages/eddsa-proof"
   dependencies:
-    "@ethersproject/bignumber": "npm:^5.7.0"
-    "@ethersproject/bytes": "npm:^5.7.0"
-    "@ethersproject/keccak256": "npm:^5.7.0"
     "@rollup/plugin-alias": "npm:^5.1.0"
     "@rollup/plugin-json": "npm:^6.1.0"
     "@rollup/plugin-typescript": "npm:^11.1.6"
@@ -3584,6 +3581,7 @@ __metadata:
     "@types/tmp": "npm:^0.2.6"
     "@zk-kit/eddsa-poseidon": "npm:1.0.0-beta"
     "@zk-kit/utils": "npm:1.0.0-beta.4"
+    ethers: "npm:^6.12.0"
     poseidon-lite: "npm:^0.2.0"
     rimraf: "npm:^5.0.5"
     rollup: "npm:^4.12.0"
@@ -3696,6 +3694,7 @@ __metadata:
     "@types/snarkjs": "npm:^0"
     "@types/tmp": "npm:^0.2.6"
     "@zk-kit/utils": "npm:1.0.0-beta.4"
+    ethers: "npm:^6.12.0"
     poseidon-lite: "npm:^0.2.0"
     rimraf: "npm:^5.0.5"
     rollup: "npm:^4.12.0"
@@ -7928,7 +7927,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethers@npm:^6.4.0":
+"ethers@npm:^6.12.0, ethers@npm:^6.4.0":
   version: 6.12.0
   resolution: "ethers@npm:6.12.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3684,9 +3684,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@zk-kit/poseidon-proof@workspace:packages/poseidon-proof"
   dependencies:
-    "@ethersproject/bignumber": "npm:^5.7.0"
-    "@ethersproject/bytes": "npm:^5.7.0"
-    "@ethersproject/keccak256": "npm:^5.7.0"
     "@rollup/plugin-alias": "npm:^5.1.0"
     "@rollup/plugin-json": "npm:^6.1.0"
     "@rollup/plugin-typescript": "npm:^11.1.6"


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

This PR changes the type of the `scope` parameter in the following packages: `@zk-kit/eddsa-proof`, `@zk-kit/poseidon-proof`. `scope` can now also be text.

Additionally, it include the number of inputs of the `poseidon-proof` package in the proof object, so that the `verify` function doesn't need it as a separate parameter. 

## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

Closes #214

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
<!-- Feel free to remove this section if you will not use it. -->

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
