### PR TITLE
ci: skip contract tests when PR changes are unrelated

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -41,6 +41,13 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v4
 
+            - name: Get changed files
+              id: changed-files-contracts
+              uses: tj-actions/changed-files@v44
+              with:
+                  files: |
+                      packages/**.sol/**
+
             - name: Setup Node
               uses: actions/setup-node@v4
               with:
@@ -70,4 +77,6 @@ jobs:
               run: yarn build
 
             - name: Test ${{ matrix.type }}
+              # this condition is to skip contract tests when PR changes are unrelated
+              if: matrix.type != 'contracts' || steps.changed-files-contracts.outputs.any_changed == 'true'
               run: yarn test:${{ matrix.type }}


### PR DESCRIPTION
This PR skips contract tests when changes are unrelated to contract files. Specifically, contract tests will only be triggered if files under `packages/**/*.sol` are modified