### PR TITLE
chore(utils): remove unexisting snark-artifacts exports

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -48,15 +48,6 @@
             "types": "./dist/types/f1-field.d.ts",
             "require": "./dist/lib.commonjs/f1-field.cjs",
             "default": "./dist/lib.esm/f1-field.js"
-        },
-        "./snark-artifacts": {
-            "types": "./dist/types/snark-artifacts/snark-artifacts.browser.d.ts",
-            "node": {
-                "require": "./dist/lib.commonjs/snark-artifacts/snark-artifacts.node.cjs",
-                "default": "./dist/lib.esm/snark-artifacts/snark-artifacts.node.js"
-            },
-            "browser": "./dist/lib.esm/snark-artifacts/snark-artifacts.browser.js",
-            "default": "./dist/lib.esm/snark-artifacts/snark-artifacts.browser.js"
         }
     },
     "files": [


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

This PR removes the `snark-artifacts` exports from the package.json file in the utils package, as that module no longer exists.

## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

Closes #287

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
