### PR TITLE
fix(eddsa-poseidon): set default private key as buffer

### DIFF
--- a/packages/eddsa-poseidon/src/eddsa-poseidon.ts
+++ b/packages/eddsa-poseidon/src/eddsa-poseidon.ts
@@ -11,12 +11,7 @@ import {
 } from "@zk-kit/baby-jubjub"
 import type { BigNumberish } from "@zk-kit/utils"
 import { crypto, requireBuffer } from "@zk-kit/utils"
-import {
-    bigNumberishToBigInt,
-    leBigIntToBuffer,
-    leBufferToBigInt,
-    bufferToHexadecimal
-} from "@zk-kit/utils/conversions"
+import { bigNumberishToBigInt, leBigIntToBuffer, leBufferToBigInt } from "@zk-kit/utils/conversions"
 import { requireBigNumberish } from "@zk-kit/utils/error-handlers"
 import F1Field from "@zk-kit/utils/f1-field"
 import * as scalar from "@zk-kit/utils/scalar"
@@ -274,7 +269,7 @@ export class EdDSAPoseidon {
      *
      * @param privateKey The private key used for signing and public key derivation.
      */
-    constructor(privateKey: Buffer | Uint8Array | string = bufferToHexadecimal(crypto.getRandomValues(32))) {
+    constructor(privateKey: Buffer | Uint8Array | string = crypto.getRandomValues(32)) {
         this.privateKey = privateKey
         this.secretScalar = deriveSecretScalar(privateKey)
         this.publicKey = derivePublicKey(privateKey)

--- a/packages/eddsa-poseidon/tests/index.test.ts
+++ b/packages/eddsa-poseidon/tests/index.test.ts
@@ -375,6 +375,7 @@ describe("EdDSAPoseidon", () => {
 
         const signature = eddsa.signMessage(message)
 
+        expect(typeof eddsa.privateKey).toBe("string")
         expect(eddsa.secretScalar).toBe(deriveSecretScalar(privateKey))
         expect(eddsa.packedPublicKey).toBe(packPublicKey(eddsa.publicKey))
         expect(eddsa.verifySignature(message, signature)).toBeTruthy()

--- a/packages/eddsa-poseidon/tests/index.test.ts
+++ b/packages/eddsa-poseidon/tests/index.test.ts
@@ -385,8 +385,8 @@ describe("EdDSAPoseidon", () => {
 
         const signature = eddsa.signMessage(message)
 
-        expect(typeof eddsa.privateKey).toBe("string")
-        expect(eddsa.privateKey).toHaveLength(64)
+        expect(typeof eddsa.privateKey).toBe("object")
+        expect(eddsa.privateKey).toHaveLength(32)
         expect(eddsa.secretScalar).toBe(deriveSecretScalar(eddsa.privateKey))
         expect(eddsa.packedPublicKey).toBe(packPublicKey(eddsa.publicKey))
         expect(eddsa.verifySignature(message, signature)).toBeTruthy()

--- a/packages/eddsa-poseidon/tests/index.test.ts
+++ b/packages/eddsa-poseidon/tests/index.test.ts
@@ -376,6 +376,7 @@ describe("EdDSAPoseidon", () => {
         const signature = eddsa.signMessage(message)
 
         expect(typeof eddsa.privateKey).toBe("string")
+        expect(eddsa.privateKey).toBe(privateKey)
         expect(eddsa.secretScalar).toBe(deriveSecretScalar(privateKey))
         expect(eddsa.packedPublicKey).toBe(packPublicKey(eddsa.publicKey))
         expect(eddsa.verifySignature(message, signature)).toBeTruthy()


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

The private key must always be 1 of the following supported types: buffer, uint8array, or text. The default private key generated in the constructor was a hexadecimal string and it was considered text by the internal functions. The default private key is a buffer now, which eliminates the ambiguity.

## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

Fixes #297

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
