### PR TITLE
chore: bump `@zk-kit/artifacts` to `1.8.0`

### DIFF
--- a/packages/poseidon-proof/README.md
+++ b/packages/poseidon-proof/README.md
@@ -51,8 +51,8 @@ Originally developed for integration with [Semaphore V4](https://github.com/sema
 
 The Snark artifacts (`.wasm` and `.zkey` files) can be specified or not in the `generate` function parameters and can possibly be downloaded using the following URLs:
 
--   https://zkkit.cedoor.dev/poseidon-proof/artifacts/${numberOfInputs}/poseidon-proof.wasm
--   https://zkkit.cedoor.dev/poseidon-proof/artifacts/${numberOfInputs}/poseidon-proof.zkey
+-   https://snark-artifacts.pse.dev/poseidon/{version}/poseidon-{numberOfInputs}.wasm
+-   https://snark-artifacts.pse.dev/poseidon/{version}/poseidon-{numberOfInputs}.zkey
 
 > [!WARNING]  
 > The Snark artifacts currently used to generate zero-knowledge proofs are the result of an insecure trusted setup, and the library has not yet been audited. Therefore, it is advised not to use it in production.

--- a/packages/poseidon-proof/package.json
+++ b/packages/poseidon-proof/package.json
@@ -45,7 +45,7 @@
         "rollup-plugin-cleanup": "^3.2.1"
     },
     "dependencies": {
-        "@zk-kit/artifacts": "1.4.1",
+        "@zk-kit/artifacts": "1.8.0",
         "@zk-kit/utils": "1.2.0",
         "ethers": "^6.12.0",
         "snarkjs": "^0.7.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2992,10 +2992,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@zk-kit/artifacts@npm:1.4.1":
-  version: 1.4.1
-  resolution: "@zk-kit/artifacts@npm:1.4.1"
-  checksum: 10/8ffacce0868eafb41679c0908c31f87e8cb75f9b5ab7ca3e55d69ba96765422af24669d230a019f65f4f796124d8cad2f0f80bce1aae02fc376f24c8ed46e4b5
+"@zk-kit/artifacts@npm:1.8.0":
+  version: 1.8.0
+  resolution: "@zk-kit/artifacts@npm:1.8.0"
+  checksum: 10/f2eedd395d1662dc77780366edbbfbb9e543a82880dccfdc39dbf412010b65dabce9a64903218e64b9059fe7d9c02214e0f7817250a7ff4342836353d75d02dd
   languageName: node
   linkType: hard
 
@@ -3118,7 +3118,7 @@ __metadata:
     "@types/download": "npm:^8.0.5"
     "@types/snarkjs": "npm:^0"
     "@types/tmp": "npm:^0.2.6"
-    "@zk-kit/artifacts": "npm:1.4.1"
+    "@zk-kit/artifacts": "npm:1.8.0"
     "@zk-kit/utils": "npm:1.2.0"
     ethers: "npm:^6.12.0"
     ffjavascript: "npm:^0.3.0"


### PR DESCRIPTION
1.8.0 uses the new pse public cdn to download artifacts:
ex: https://snark-artifacts.pse.dev/poseidon/latest/poseidon-4.wasm