### PR TITLE
refactor(eddsa-poseidon)!: restrict message types

### DIFF
--- a/packages/eddsa-poseidon/src/eddsa-poseidon.ts
+++ b/packages/eddsa-poseidon/src/eddsa-poseidon.ts
@@ -9,7 +9,7 @@ import {
     subOrder,
     unpackPoint
 } from "@zk-kit/baby-jubjub"
-import type { BigNumberish } from "@zk-kit/utils"
+import type { BigNumber, BigNumberish } from "@zk-kit/utils"
 import { crypto, requireBuffer } from "@zk-kit/utils"
 import { bigNumberishToBigInt, leBigIntToBuffer, leBufferToBigInt } from "@zk-kit/utils/conversions"
 import { requireBigNumberish } from "@zk-kit/utils/error-handlers"
@@ -87,7 +87,7 @@ export function derivePublicKey(privateKey: Buffer | Uint8Array | string): Point
  * @param message The message to be signed.
  * @returns The signature object, containing properties relevant to EdDSA signatures, such as 'R8' and 'S' values.
  */
-export function signMessage(privateKey: Buffer | Uint8Array | string, message: BigNumberish): Signature<bigint> {
+export function signMessage(privateKey: Buffer | Uint8Array | string, message: BigNumber): Signature<bigint> {
     // Convert the private key to buffer.
     privateKey = checkPrivateKey(privateKey)
 
@@ -121,7 +121,7 @@ export function signMessage(privateKey: Buffer | Uint8Array | string, message: B
  * @param publicKey The public key associated with the private key used to sign the message.
  * @returns Returns true if the signature is valid and corresponds to the message and public key, false otherwise.
  */
-export function verifySignature(message: BigNumberish, signature: Signature, publicKey: Point): boolean {
+export function verifySignature(message: BigNumber, signature: Signature, publicKey: Point): boolean {
     if (
         !isPoint(publicKey) ||
         !isSignature(signature) ||
@@ -281,7 +281,7 @@ export class EdDSAPoseidon {
      * @param message The message to be signed.
      * @returns The signature of the message.
      */
-    signMessage(message: BigNumberish): Signature<bigint> {
+    signMessage(message: BigNumber): Signature<bigint> {
         return signMessage(this.privateKey, message)
     }
 
@@ -291,7 +291,7 @@ export class EdDSAPoseidon {
      * @param signature The signature to be verified.
      * @returns True if the signature is valid for the message and public key, false otherwise.
      */
-    verifySignature(message: BigNumberish, signature: Signature): boolean {
+    verifySignature(message: BigNumber, signature: Signature): boolean {
         return verifySignature(message, signature, this.publicKey)
     }
 }

--- a/packages/eddsa-poseidon/src/utils.ts
+++ b/packages/eddsa-poseidon/src/utils.ts
@@ -1,5 +1,5 @@
 import { Point } from "@zk-kit/baby-jubjub"
-import type { BigNumberish } from "@zk-kit/utils"
+import { type BigNumberish } from "@zk-kit/utils"
 import { bigNumberishToBigInt, bufferToBigInt } from "@zk-kit/utils/conversions"
 import { requireTypes } from "@zk-kit/utils/error-handlers"
 import { isArray, isBigNumber, isBigNumberish, isObject } from "@zk-kit/utils/type-checks"


### PR DESCRIPTION
BREAKING CHANGE: message type

re #230

## Description
The type supported for the EdDSA message has been reduced to BigNumber (either bigint or string which  must still be a stringified bigint))
<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
<!-- Feel free to remove this section if you will not use it. -->

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
