### PR TITLE
docs: include `logical-expressions` in typedoc

### DIFF
--- a/packages/logical-expressions/typedoc.json
+++ b/packages/logical-expressions/typedoc.json
@@ -1,3 +1,5 @@
 {
-    "entryPoints": ["src/index.ts"]
+    "entryPoints": [
+        "src/index.ts"
+    ]
 }


### PR DESCRIPTION
Fix #335
