### PR TITLE
docs: add paper download link to readme files

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,4 @@
 {
-    "**/*.{js,ts,jsx,tsx,md,json,yml,yaml}": "prettier --write",
+    "**/*.{js,ts,jsx,tsx,md,json,yml,yaml}": "yarn prettier --write",
     "**/*.{js,ts,jsx,tsx}": "eslint"
 }

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,4 @@
 {
-    "**/*.{js,ts,jsx,tsx,md,json,yml,yaml}": "yarn prettier --write",
+    "**/*.{js,ts,jsx,tsx,md,json,yml,yaml}": "prettier --write",
     "**/*.{js,ts,jsx,tsx}": "eslint"
 }

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@
 -   Rust: [privacy-scaling-explorations/zk-kit.rust](https://github.com/privacy-scaling-explorations/zk-kit.rust)
 -   Solidity: [privacy-scaling-explorations/zk-kit.solidity](https://github.com/privacy-scaling-explorations/zk-kit.solidity)
 
+## 📄 Papers
+
+-   LeanIMT ([Download PDF](https://github.com/privacy-scaling-explorations/zk-kit/raw/main/papers/leanimt/paper/leanimt-paper.pdf))
+
 ## 📦 Packages
 
 <table>

--- a/papers/leanimt/README.md
+++ b/papers/leanimt/README.md
@@ -1,6 +1,6 @@
 # LeanIMT Paper
 
-This folder contains the LeanIMT Paper.
+This folder contains the LeanIMT Paper ([Download PDF](https://github.com/privacy-scaling-explorations/zk-kit/raw/main/papers/leanimt/paper/leanimt-paper.pdf)).
 
 ## Related work
 


### PR DESCRIPTION
## Description

This PR adds the download paper link to make it easier to download the PDF document.

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
