### PR TITLE
fix(eddsa-poseidon): Check size of the message parameter

### DIFF
--- a/packages/eddsa-poseidon/src/utils.ts
+++ b/packages/eddsa-poseidon/src/utils.ts
@@ -59,18 +59,21 @@ export function checkPrivateKey(privateKey: Buffer | Uint8Array | string): Buffe
 }
 
 /**
- * Validates and converts a BigNumberish message to a bigint.
+ * Validates and converts a BigNumberish message to a bigint. Ensures the message size does not exceed 32 bytes.
  * @param message The message to check and convert.
  * @returns The message as a bigint.
  */
 export function checkMessage(message: BigNumberish): bigint {
     requireTypes(message, "message", ["bignumberish", "string"])
 
-    if (isBigNumberish(message)) {
-        return bigNumberishToBigInt(message)
-    }
+    const bigIntMessage =
+        isBigNumberish(message) && message
+            ? bigNumberishToBigInt(message)
+            : bufferToBigInt(Buffer.from(message as string))
 
-    return bufferToBigInt(Buffer.from(message as string))
+    const maxLength = 2n ** 256n / 2n - 1n
+    if (bigIntMessage > maxLength) throw new Error(`Message length is larger than 32 bytes`)
+    return bigIntMessage
 }
 
 /**

--- a/packages/eddsa-poseidon/tests/eddsa-poseidon-blake1.test.ts
+++ b/packages/eddsa-poseidon/tests/eddsa-poseidon-blake1.test.ts
@@ -138,6 +138,22 @@ describe("EdDSAPoseidon", () => {
         expect(fun).toThrow(`Parameter 'message' is none of the following types: bignumberish, string`)
     })
 
+    it("Should throw an error if the message is larger than 32 Bytes [string]", async () => {
+        const message = "abcdefghijklmnopqrstuvwxyz1234567"
+
+        const fun = () => signMessage(privateKey, message)
+
+        expect(fun).toThrow(`Message length is larger than 32 bytes`)
+    })
+
+    it("Should throw an error if the message is larger than 32 Bytes [number]", async () => {
+        const message = 2 ** 256 / 2
+
+        const fun = () => signMessage(privateKey, message)
+
+        expect(fun).toThrow(`Message length is larger than 32 bytes`)
+    })
+
     it("Should verify a signature (numeric)", async () => {
         const publicKey = derivePublicKey(privateKey)
         const signature = signMessage(privateKey, message)


### PR DESCRIPTION
## Description

Checks the message parameter, to ensure it doesn't exceed 32 bytes, as this is required for poseidon.

## Related Issue(s)

[#190](https://github.com/privacy-scaling-explorations/zk-kit/issues/190)

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings
-   [ ] I have run `yarn style` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
