### PR TITLE
Typo fix Update README.md

### DIFF
--- a/papers/leanimt/README.md
+++ b/papers/leanimt/README.md
@@ -23,7 +23,7 @@ This folder contains the LeanIMT Paper ([Download PDF](https://github.com/privac
 3. Add the path by running:
 
 ```bash
-echo -n 'export PATH=$HOME/bin:$PATH' >> ~/.zshrc
+echo 'export PATH=$HOME/bin:$PATH' >> ~/.zshrc
 ```
 
 Read more about it [here](https://stackoverflow.com/questions/11530090/adding-a-new-entry-to-the-path-variable-in-zsh/47795375#47795375).


### PR DESCRIPTION
## Description

The command provided for adding a path to `~/.zshrc` uses the `-n` flag with `echo`:
```bash
echo -n 'export PATH=$HOME/bin:$PATH' >> ~/.zshrc
```
The `-n` flag suppresses the newline, which can cause the appended line to merge with the last line in `~/.zshrc`. This may lead to configuration errors, especially if the file does not end with a newline.

#### Fix:
The corrected command removes the `-n` flag:
```bash
echo 'export PATH=$HOME/bin:$PATH' >> ~/.zshrc
```
This ensures proper appending of the line, preventing potential issues with shell configuration.

#### Importance:
This fix is crucial for ensuring that users setting up LaTeX on Mac systems follow accurate and reliable instructions. Incorrect configurations can lead to debugging challenges, particularly for users unfamiliar with shell scripting or environment setup.

#### Changes:
- Updated the relevant command in the documentation to remove the `-n` flag from `echo`.

#### Testing:
Tested the corrected command on macOS with Zsh to verify that it appends the path configuration properly to `~/.zshrc` without breaking existing configurations.

Please review and merge to improve the accuracy of the setup guide. 😊

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
