### PR TITLE
perf(imt): when updating a node, skip calculation if value is the same

### DIFF
--- a/packages/imt/src/imt.ts
+++ b/packages/imt/src/imt.ts
@@ -224,6 +224,8 @@ export default class IMT {
             throw new Error("The leaf does not exist in this tree")
         }
 
+        if (newLeaf === this._nodes[0][index]) return
+
         let node = newLeaf
 
         for (let level = 0; level < this.depth; level += 1) {

--- a/packages/imt/tests/imt.test.ts
+++ b/packages/imt/tests/imt.test.ts
@@ -131,6 +131,25 @@ describe("IMT", () => {
                         expect(tree.root).toEqual(root)
                     }
                 })
+
+                it(`Should not error when update value is the same`, () => {
+                    for (let i = 0; i < numberOfLeaves; i += 1) {
+                        tree.insert(1)
+                        oldTree.insert(1)
+                    }
+
+                    const previousRoot = tree.root
+
+                    for (let i = 0; i < numberOfLeaves; i += 1) {
+                        tree.update(i, 1)
+                        oldTree.update(i, 1)
+
+                        const { root } = oldTree.genMerklePath(0)
+
+                        expect(tree.root).toEqual(root)
+                        expect(tree.root).toEqual(previousRoot)
+                    }
+                })
             })
 
             describe("# indexOf", () => {


### PR DESCRIPTION



<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

In order to improve performance, we can avoid recalculating the Incremental Merkel Tree in the event that the update value is the same as the tree value.

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

## Related Issue(s)

Closes #340


## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
