### PR TITLE
Fix broken and incorrect links README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@
                 <a href="https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/poseidon-cipher">
                     @zk-kit/poseidon-cipher
                 </a>
-                 <a href="https://zkkit.pse.dev/modules/_zk_kit_poseidon_chiper.html">
+                 <a href="https://zkkit.pse.dev/modules/_zk_kit_poseidon_cipher.html">
                     (docs)
                 </a>
             </td>
@@ -346,7 +346,7 @@
                 <a href="https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/logical-expressions">
                     @zk-kit/logical-expressions
                 </a>
-                 <a href="https://zkkit.pse.dev/modules/_zk_kit_poseidon_proof.html">
+                 <a href="https://zkkit.pse.dev/modules/_zk_kit_logical_expressions.html">
                     (docs)
                 </a>
             </td>


### PR DESCRIPTION
#### Description  
This PR updates two incorrect links in the `README.md` file:  
- Fixed the `poseidon-cipher` documentation link to point to the correct URL.  
- Updated the `logical-expressions` documentation link to the correct URL.  

These changes ensure that users can access the correct documentation for the corresponding packages.  

#### Checklist  
- [x] My code follows the style guidelines of this project.  
- [x] I have performed a self-review of my code.  
- [ ] I have commented my code, particularly in hard-to-understand areas.  
- [x] My changes generate no new warnings.  
- [x] I have run `yarn style` without getting any errors.  
- [ ] I have added tests that prove my fix is effective or that my feature works.  
- [x] New and existing unit tests pass locally with my changes.  
