### PR TITLE
Update README.md - Fix Spelling and Grammar

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -79,8 +79,8 @@ SparseMT - Generated 500 proofs x 2,789 ops/sec ±2.63% (68 runs sampled)
 Fastest is IMT - Generated 500 proofs
 ```
 
-The Benchmarks suggested in the index.ts are for **8, 128 and 1024 leafs** to see how each Merkle tree for different sizes of trees
-perform because their theorical expected behavior described [here](https://github.com/privacy-scaling-explorations/zk-kit?tab=readme-ov-file#i-need-to-use-a-merkle-tree-to-prove-the-inclusion-or-exclusion-of-data-elements-within-a-set-which-type-of-merkle-tree-should-i-use).
+The Benchmarks suggested in the index.ts are for **8, 128 and 1024 leaves** to see how each Merkle tree for different sizes of trees
+perform because their theoretical expected behavior described [here](https://github.com/privacy-scaling-explorations/zk-kit?tab=readme-ov-file#i-need-to-use-a-merkle-tree-to-prove-the-inclusion-or-exclusion-of-data-elements-within-a-set-which-type-of-merkle-tree-should-i-use).
 
 ## Dependencies
 


### PR DESCRIPTION

## Description

This PR fixes spelling errors in the benchmarks documentation to improve clarity and technical accuracy.

### Changes Made in `benchmarks/README.md`:

1. Changed "leafs" to "leaves" (correct plural form)
2. Changed "theorical" to "theoretical" (correct spelling)

Before:
The Benchmarks suggested in the index.ts are for **8, 128 and 1024 leafs** to see how each Merkle tree for different sizes of trees perform because their theorical expected behavior...

After:
The Benchmarks suggested in the index.ts are for **8, 128 and 1024 leaves** to see how each Merkle tree for different sizes of trees perform because their theoretical expected behavior...

## Rationale

1. "Leaves" is the correct plural form of "leaf" in technical contexts, especially when referring to tree data structures
2. "Theoretical" is the correct spelling of the word describing concepts based on theory rather than practice

## Related Issue(s)
<!-- If this PR fixes any open issues, please list them here -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings
- [x] Documentation has been updated appropriately

These changes improve the technical accuracy and professional appearance of the documentation.