### PR TITLE
 Fix Typo in "Deleted Method"

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -45,7 +45,7 @@ The benchmark includes the following tests for each Merkle Tree implementation:
 2. Generate Proofs: Measures the performance of generating Merkle proofs.
 3. Verify Proofs: Measures how quickly the generated proofs can be verified.
 4. Update Leaves: Measures how quickly the leaves can be updated.
-5. Delete Leaves: Measures how quickly the leaves can be deleted. The Lean Merkle tree is excluded because it does not have deleted method implemented.
+5. Delete Leaves: Measures how quickly the leaves can be deleted. The Lean Merkle tree is excluded because it does not have delete method implemented.
 
 ## Benchmark Structure.
 


### PR DESCRIPTION
<img width="855" alt="Снимок экрана 2024-12-04 в 19 28 07" src="https://github.com/user-attachments/assets/8750648a-8146-48d5-98fb-df848ca7ca80">

This phrasing is incorrect because "deleted" refers to a state, not the action of deleting. In programming, methods are named after the actions they perform, so the correct term is "delete method."  

The updated phrasing now reads:  
> "The Lean Merkle tree is excluded because it does not have the **delete method** implemented."  

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
