### PR TITLE
Fix grammar in README.md

### DIFF
--- a/packages/smt/README.md
+++ b/packages/smt/README.md
@@ -92,7 +92,7 @@ import { poseidon2, poseidon3 } from "poseidon-lite"
 // Hexadecimal hashes.
 const hash = (childNodes: ChildNodes) => sha256(childNodes.join("")).toString()
 
-// Create the SMT with an Hexadecimal (SHA256) hash.
+// Create the SMT with a Hexadecimal (SHA256) hash.
 const tree = new SMT(hash)
 
 // 0


### PR DESCRIPTION
This pull request addresses a minor grammatical issue in the `README.md` file. The phrase "an Hexadecimal" was changed to "a Hexadecimal" to correctly follow the rule of using "a" before words starting with a consonant sound. This small correction ensures the clarity and accuracy of the documentation.

**Checklist**:
- [x] Fixed grammatical error in `README.md` file.
