### PR TITLE
Fix grammatical and spelling issues in documentation

### DIFF
--- a/benchmarks/benchmark-merkle-trees.ts
+++ b/benchmarks/benchmark-merkle-trees.ts
@@ -65,7 +65,7 @@ export default function run(treeDepth: number, numberOfLeaves: number) {
     let leafIMT = 0
     let leafLeanIMT = 0
     let leafSMT = 0
-    /*  Number of leafs to take as sample to benchmark.
+    /*  Number of leaves to take as sample to benchmark.
         It acts as a limit to stop doing the operation (delete) or restart the cycle
         counter controller (update, proof, verification) in a benchmark since
         the benny suite does not have the method to limit the maximum of operations

--- a/packages/eddsa-poseidon/src/eddsa-poseidon-factory.ts
+++ b/packages/eddsa-poseidon/src/eddsa-poseidon-factory.ts
@@ -119,7 +119,7 @@ export const EdDSAPoseidonFactory = (algorithm: SupportedHashingAlgorithms) => {
 
     /**
      * Verifies an EdDSA signature using the Baby Jubjub elliptic curve and Poseidon hash function.
-     * @param message The original message that was be signed.
+     * @param message The original message that was signed.
      * @param signature The EdDSA signature to be verified.
      * @param publicKey The public key associated with the private key used to sign the message.
      * @returns Returns true if the signature is valid and corresponds to the message and public key, false otherwise.

--- a/packages/imt/src/imt.ts
+++ b/packages/imt/src/imt.ts
@@ -43,7 +43,7 @@ export default class IMT {
     private readonly _arity: number
 
     /**
-     * It initializes the tree with an hash function, the depth, the zero value to use for zeroes
+     * It initializes the tree with a hash function, the depth, the zero value to use for zeroes
      * and the arity (i.e. the number of children for each node). It also takes an optional parameter
      * to initialize the tree with a list of leaves.
      * @param hash The hash function used to create nodes.


### PR DESCRIPTION

Changes in packages/imt/src/imt.ts:

1. "leafs" -> "leaves" 
   Reason: "Leaves" is the correct plural form of "leaf"

2. "that was be signed" -> "that was signed"
   Reason: Removed redundant "be" for correct grammar

3. "with an hash function" -> "with a hash function" 
   Reason: "A" is used before consonant sounds, "hash" begins with consonant

Documentation-only changes, no functional code affected. No tests required.