### PR TITLE
fix: Fix element order in proof.pi_b Update proof-packing.ts

### DIFF
--- a/packages/utils/src/proof-packing.ts
+++ b/packages/utils/src/proof-packing.ts
@@ -18,10 +18,10 @@ export function packGroth16Proof(proof: Groth16Proof): PackedGroth16Proof {
     return [
         proof.pi_a[0],
         proof.pi_a[1],
-        proof.pi_b[0][1],
         proof.pi_b[0][0],
-        proof.pi_b[1][1],
+        proof.pi_b[0][1],
         proof.pi_b[1][0],
+        proof.pi_b[1][1],
         proof.pi_c[0],
         proof.pi_c[1]
     ]


### PR DESCRIPTION
## Description

I noticed that the order of elements in `proof.pi_b` was incorrect, which could lead to issues when unpacking the proof. Specifically, `proof.pi_b[0][1]` and `proof.pi_b[0][0]` were swapped, as were `proof.pi_b[1][1]` and `proof.pi_b[1][0]`.  

This fix ensures the elements are in the correct order, aligning with the structure expected by the `unpackGroth16Proof` function. This should prevent any potential bugs or mismatches during proof unpacking.  

## Checklist

-   [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CODE_OF_CONDUCT.md).
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

