### PR TITLE
fix: fix in message text Update index.test.ts

### DIFF
--- a/packages/logical-expressions/tests/index.test.ts
+++ b/packages/logical-expressions/tests/index.test.ts
@@ -217,7 +217,7 @@ describe("Logical Expressions", () => {
         it("Should throw an error if the logical expression is invalid and has two binary operators with the same precedence", () => {
             const expression = ["and", "or"]
             const fun = () => evaluate(expression)
-            expect(fun).toThrow("The operator 'and' requires two value")
+            expect(fun).toThrow("The operator 'and' requires two values")
         })
         it("Should throw an error if the logical expression is empty", () => {
             const expression: string[] = []


### PR DESCRIPTION
## Description

A typo in the message text where "two value" was used instead of "two values".

## Checklist

-   [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CODE_OF_CONDUCT.md).
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
