### PR TITLE
feat(utils): support boolean in types-checks and error-handlers

### DIFF
--- a/packages/utils/src/error-handlers.ts
+++ b/packages/utils/src/error-handlers.ts
@@ -14,6 +14,7 @@ import {
     isBigInt,
     isBigNumber,
     isBigNumberish,
+    isBoolean,
     isBuffer,
     isDefined,
     isFunction,
@@ -46,6 +47,17 @@ export function requireDefined(parameterValue: any, parameterName: string) {
 export function requireNumber(parameterValue: number, parameterName: string) {
     if (!isNumber(parameterValue)) {
         throw new TypeError(`Parameter '${parameterName}' is not a number, received type: ${typeof parameterValue}`)
+    }
+}
+
+/**
+ * @throws Throws a type error if the parameter value is not a boolean.
+ * @param parameterValue The parameter value.
+ * @param parameterName The parameter name.
+ */
+export function requireBoolean(parameterValue: boolean, parameterName: string) {
+    if (!isBoolean(parameterValue)) {
+        throw new TypeError(`Parameter '${parameterName}' is not a boolean, received type: ${typeof parameterValue}`)
     }
 }
 

--- a/packages/utils/src/type-checks.ts
+++ b/packages/utils/src/type-checks.ts
@@ -12,6 +12,7 @@ import { Buffer } from "buffer"
 /** @internal */
 export const supportedTypes = [
     "number",
+    "boolean",
     "string",
     "function",
     "Array",
@@ -41,6 +42,14 @@ export function isDefined(value: any): boolean {
  */
 export function isNumber(value: any): boolean {
     return typeof value === "number"
+}
+
+/**
+ * Returns true if the value is a boolean, false otherwise.
+ * @param value The value to be checked.
+ */
+export function isBoolean(value: any): boolean {
+    return typeof value === "boolean"
 }
 
 /**
@@ -179,6 +188,8 @@ export function isType(value: any, type: SupportedType): boolean {
     switch (type) {
         case "number":
             return isNumber(value)
+        case "boolean":
+            return isBoolean(value)
         case "string":
             return isString(value)
         case "function":

--- a/packages/utils/tests/error-handlers.test.ts
+++ b/packages/utils/tests/error-handlers.test.ts
@@ -3,6 +3,7 @@ import {
     requireBigInt,
     requireBigNumber,
     requireBigNumberish,
+    requireBoolean,
     requireBuffer,
     requireDefined,
     requireFunction,
@@ -36,6 +37,18 @@ describe("# error-handlers", () => {
 
     it("Should not throw an error if the parameter is a number", () => {
         const fun = () => requireNumber(1, "parameter")
+
+        expect(fun).not.toThrow()
+    })
+
+    it("Should throw an error if the parameter is not a boolean", () => {
+        const fun = () => requireBoolean("euo" as any, "parameter")
+
+        expect(fun).toThrow("Parameter 'parameter' is not a boolean")
+    })
+
+    it("Should not throw an error if the parameter is a boolean", () => {
+        const fun = () => requireBoolean(true, "parameter")
 
         expect(fun).not.toThrow()
     })

--- a/packages/utils/tests/type-checks.test.ts
+++ b/packages/utils/tests/type-checks.test.ts
@@ -4,6 +4,7 @@ import {
     isBigInt,
     isBigNumber,
     isBigNumberish,
+    isBoolean,
     isBuffer,
     isFunction,
     isHexadecimal,
@@ -23,6 +24,14 @@ describe("# type-checks", () => {
 
     it("Should return false if the value is not a number", () => {
         expect(isNumber("string")).toBeFalsy()
+    })
+
+    it("Should return true if the value is a boolean", () => {
+        expect(isBoolean(true)).toBeTruthy()
+    })
+
+    it("Should return false if the value is not a boolean", () => {
+        expect(isBoolean("string")).toBeFalsy()
     })
 
     it("Should return true if the value is a string", () => {
@@ -120,6 +129,7 @@ describe("# type-checks", () => {
 
     it("Should return true if the value type is the one expected", () => {
         expect(isType(1, "number")).toBeTruthy()
+        expect(isType(false, "boolean")).toBeTruthy()
         expect(isType("string", "string")).toBeTruthy()
         expect(isType(() => true, "function")).toBeTruthy()
         expect(isType([], "Array")).toBeTruthy()
@@ -137,6 +147,7 @@ describe("# type-checks", () => {
 
     it("Should return false if the value type is not the one expected or is not supported", () => {
         expect(isType("string", "number")).toBeFalsy()
+        expect(isType(1, "boolean")).toBeFalsy()
         expect(isType(1, "string")).toBeFalsy()
         expect(isType(1, "function")).toBeFalsy()
         expect(isType(1, "Array")).toBeFalsy()

--- a/packages/utils/tests/type-checks.test.ts
+++ b/packages/utils/tests/type-checks.test.ts
@@ -165,6 +165,18 @@ describe("# type-checks", () => {
 
     it("Should return true if the type is supported", () => {
         expect(isSupportedType("number")).toBeTruthy()
+        expect(isSupportedType("boolean")).toBeTruthy()
+        expect(isSupportedType("string")).toBeTruthy()
+        expect(isSupportedType("function")).toBeTruthy()
+        expect(isSupportedType("Array")).toBeTruthy()
+        expect(isSupportedType("Uint8Array")).toBeTruthy()
+        expect(isSupportedType("Buffer")).toBeTruthy()
+        expect(isSupportedType("object")).toBeTruthy()
+        expect(isSupportedType("bigint")).toBeTruthy()
+        expect(isSupportedType("stringified-bigint")).toBeTruthy()
+        expect(isSupportedType("hexadecimal")).toBeTruthy()
+        expect(isSupportedType("bignumber")).toBeTruthy()
+        expect(isSupportedType("bignumberish")).toBeTruthy()
     })
 
     it("Should return false if the type is not supported", () => {


### PR DESCRIPTION
## Description

This PR adds support to check boolean values in the `TypeChecks` and `ErrorHandlers` modules.

## Related Issue(s)

Closes #372

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CODE_OF_CONDUCT.md).
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical mistake, please feel free to message the team.
