### PR TITLE
Fix type name inconsistency in stringifiedBigint

### DIFF
--- a/packages/utils/src/type-checks.ts
+++ b/packages/utils/src/type-checks.ts
@@ -20,7 +20,7 @@ export const supportedTypes = [
     "Buffer",
     "object",
     "bigint",
-    "stringified-bigint",
+    "stringifiedBigint",
     "hexadecimal",
     "bignumber",
     "bignumberish"
@@ -204,7 +204,7 @@ export function isType(value: any, type: SupportedType): boolean {
             return isObject(value)
         case "bigint":
             return isBigInt(value)
-        case "stringified-bigint":
+        case "stringifiedBigint":
             return isStringifiedBigInt(value)
         case "hexadecimal":
             return isHexadecimal(value)


### PR DESCRIPTION
## Description

Fixed a typo in `packages/utils/src/type-checks.ts` where the type name `"stringified-bigint"` did not match the function name `isStringifiedBigInt`. Changed the type name to `"stringifiedBigint"` to ensure naming consistency and prevent potential errors when using the `isType` function.

## Related Issue(s)

Fixes #[issue_number]

## Checklist

- [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CODE_OF_CONDUCT.md).
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have run `yarn style` without getting any errors
- [x] I have added tests that prove my fix is effective