### PR TITLE
fix: fix method name in PolField class

### DIFF
--- a/types/ffjavascript/index.d.ts
+++ b/types/ffjavascript/index.d.ts
@@ -269,7 +269,7 @@ declare module "ffjavascript" {
 
         add(...args: any[]): void
 
-        computeVanishingPolinomial(...args: any[]): void
+        computeVanishingPolynomial(...args: any[]): void
 
         div(...args: any[]): void
 


### PR DESCRIPTION
## Description  
I’ve corrected the method name in the PolField class. The method `computeVanishingPolinomial` was misspelled, and it's now updated to `computeVanishingPolynomial`.

## Related Issue(s)  
N/A

## Other information  
No additional context needed for this change.

## Checklist

-   [ ] I have read and understand the [[contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CONTRIBUTING.md)](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CONTRIBUTING.md) and [[code of conduct](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CODE_OF_CONDUCT.md)](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CODE_OF_CONDUCT.md).
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings
-   [ ] I have run `yarn style` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes