### PR TITLE
Fix precedence order and HTML structure in README

### DIFF
--- a/packages/logical-expressions/README.md
+++ b/packages/logical-expressions/README.md
@@ -1,9 +1,9 @@
-<p align="center">
+<div align="center">
     <h1 align="center">
         Logical Expressions
     </h1>
     <p align="center">A library to evaluate logical expressions.</p>
-</p>
+</div>
 
 <p align="center">
     <a href="https://github.com/privacy-scaling-explorations/zk-kit">

--- a/packages/logical-expressions/src/evaluate.ts
+++ b/packages/logical-expressions/src/evaluate.ts
@@ -15,10 +15,10 @@
  * console.log(result) // Output: 1
  */
 export function precedence(operator: string): number {
-    if (operator === "not") return 2 // Highest precedence
-    if (operator === "and") return 1
+    if (operator === "not") return 3 // Highest precedence
+    if (operator === "and") return 2
     if (operator === "xor") return 1
-    if (operator === "or") return 1 // Lowest precedence
+    if (operator === "or") return 0 // Lowest precedence
     return 0
 }
 
@@ -135,7 +135,7 @@ export function evaluate(tokens: string[]): boolean {
             ops.pop() // Remove '(' from stack
         } else if (["and", "or", "not", "xor"].includes(token)) {
             // Handle operators and ensure the correct precedence
-            while (ops.length > 0 && precedence(ops[ops.length - 1]) >= precedence(token)) {
+            while (ops.length > 0 && precedence(ops[ops.length - 1]) > precedence(token)) {
                 const op = ops.pop()!
                 if (op === "not") {
                     const val = values.pop()


### PR DESCRIPTION
1. Fixed incorrect HTML structure in `README.md`:
   - Replaced the incorrect `<p>` wrapper with `<div>` to ensure valid HTML nesting.

2. Corrected operator precedence in `evaluate.ts`:
   - Adjusted precedence values:
     - `not` now has the highest precedence (`3` instead of `2`).
     - `and` has a precedence of `2`.
     - `xor` has a precedence of `1`.
     - `or` has the lowest precedence (`0` instead of `1`).
 
3. Updated the precedence comparison logic in `evaluate()`:
     - Changed `>=` to `>` to correctly handle operator execution order.


## Checklist

- [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CODE_OF_CONDUCT.md).
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have run `yarn style` without getting any errors.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

