### PR TITLE
Grammar Fixes & Clarity Improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug.md
+++ b/.github/ISSUE_TEMPLATE/---bug.md
@@ -14,8 +14,8 @@ A clear and concise description of what the bug is.
 Steps to reproduce the behavior:
 
 1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
+2. Click on '...'
+3. Scroll down to '...'
 4. See error
 
 **Expected behavior**

--- a/benchmarks/benchmark-merkle-trees.ts
+++ b/benchmarks/benchmark-merkle-trees.ts
@@ -65,14 +65,14 @@ export default function run(treeDepth: number, numberOfLeaves: number) {
     let leafIMT = 0
     let leafLeanIMT = 0
     let leafSMT = 0
-    /*  Number of leafs to take as sample to benchmark.
+    /*  Number of leaves to take as sample for benchmarking.
         It acts as a limit to stop doing the operation (delete) or restart the cycle
         counter controller (update, proof, verification) in a benchmark since
         the benny suite does not have the method to limit the maximum of operations
         of the benchmark.
     */
     const samples = numberOfLeaves * 0.5
-    // The set of keys to do benchmarks (update, proof, verification and delete)
+    // The set of keys for benchmarking (update, proof, verification and delete)
     const sample = getNodesSample(numberOfLeaves, samples)
 
     const benchmarkSuite = (name: string, ...addFunctions: b.AddFunction[]) => {


### PR DESCRIPTION
1. .github/ISSUE_TEMPLATE/bug.md
Fixed extra dots (....) in steps for consistency:
Before: "Click on '....'" → After: "Click on '...'"
2. benchmarks/benchmark-merkle-trees.ts
Corrected plural form:
Before: "Number of leafs" → After: "Number of leaves"
Improved clarity:
Before: "to benchmark" → After: "for benchmarking"
Before: "to do benchmarks" → After: "for benchmarking"
Why?
Fixes grammar for better readability.
Ensures clear and professional documentation.