### PR TITLE
Add security warning about BigInt vulnerability

### DIFF
--- a/packages/poseidon-cipher/README.md
+++ b/packages/poseidon-cipher/README.md
@@ -29,6 +29,8 @@
     </a>
 </p>
 
+> ⚠️ **SECURITY WARNING**: This implementation uses JavaScript's native `BigInt` which is [not constant-time](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#cryptography) and may be vulnerable to timing attacks. If your application requires protection against timing attacks, consider using a constant-time cryptographic library instead. This issue is tracked in [GitHub issue #341](https://github.com/privacy-scaling-explorations/zk-kit/issues/341).
+
 <div align="center">
     <h4>
         <a href="https://appliedzkp.org/discord">

--- a/packages/poseidon-cipher/src/poseidonCipher.ts
+++ b/packages/poseidon-cipher/src/poseidonCipher.ts
@@ -10,6 +10,14 @@ import { two128 } from "./constants"
 import { CipherText, EncryptionKey, Nonce, PlainText } from "./types"
 
 /**
+ * SECURITY WARNING: This implementation uses JavaScript's native BigInt which is not constant-time
+ * and may be vulnerable to timing attacks. If your application requires protection against timing attacks,
+ * consider using a constant-time cryptographic library instead.
+ * See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#cryptography
+ * This issue is tracked in GitHub issue #341: https://github.com/privacy-scaling-explorations/zk-kit/issues/341
+ */
+
+/**
  * Encrypt some plaintext using poseidon encryption
  * @param msg - the message to encrypt
  * @param key - the key to encrypt with


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

This PR addresses the security vulnerability identified in issue #341 regarding JavaScript's native BigInt implementation in the poseidon-cipher package. The BigInt operations are not constant-time and could potentially be vulnerable to timing attacks.
As an interim solution while waiting for a constant-time library implementation, I've added clear security warnings to:
The README.md file - Added a prominent warning box after the badges section, before the main content
The poseidonCipher.ts source file - Added detailed JSDoc-style warning comments before the function definitions
Both warnings explain the nature of the vulnerability, link to Mozilla's documentation about BigInt cryptographic limitations, and reference the GitHub issue for tracking. The warnings are designed to inform users about the potential security implications when using this implementation in scenarios requiring protection against timing attacks.
This approach follows @cedoor's suggestion in the issue discussion to add documentation warnings while a more permanent solution is developed.

## Related Issue(s)

<!-- Closes # -->
Fixes #341

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CODE_OF_CONDUCT.md).
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical mistake, please feel free to message the team.
