### PR TITLE
Fix Typo in Test Comment for EdDSAPoseidon

### DIFF
--- a/packages/eddsa-poseidon/tests/eddsa-poseidon-blake1.test.ts
+++ b/packages/eddsa-poseidon/tests/eddsa-poseidon-blake1.test.ts
@@ -359,7 +359,7 @@ describe("EdDSAPoseidon", () => {
     it("Should handle a signature with values smaller than 32 bytes", async () => {
         const signature = signMessage(privateKey, message)
 
-        // S is the only value which we can easily make artifically small, since
+        // S is the only value which we can easily make artificially small, since
         // R8 has to be a point on the curve.
         // Note that overly-large values also ruled out by the inCurve check on
         // R8 and the subOrder check on S.


### PR DESCRIPTION


**Description:** 

This pull request corrects a typo in the comment within the `eddsa-poseidon-blake1.test.ts` file. The word "artifically" was changed to "artificially" to ensure clarity and accuracy in the documentation. This change does not affect the functionality of the code but improves the readability and professionalism of the comments.
