### PR TITLE
Fix broken documentation link

### DIFF
--- a/packages/poseidon-cipher/README.md
+++ b/packages/poseidon-cipher/README.md
@@ -37,7 +37,7 @@
             🗣️ Chat &amp; Support
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
-        <a href="https://zkkit.pse.dev/modules/_zk_kit_poseidon-cipher.html">
+        <a href="https://zkkit.pse.dev/modules/_zk_kit_poseidon_cipher.html">
             📘 Docs
         </a>
     </h4>


### PR DESCRIPTION
Old:
https://zkkit.pse.dev/modules/_zk_kit_poseidon-cipher.html

New:
https://zkkit.pse.dev/modules/_zk_kit_poseidon_cipher.html

Why:
The original link used a hyphen (-) instead of an underscore (_), leading to a broken page. This fix restores correct access to the Poseidon Cipher module documentation.