### PR TITLE
Fix typo in test comment

### DIFF
--- a/packages/eddsa-poseidon/tests/eddsa-poseidon-blake1.test.ts
+++ b/packages/eddsa-poseidon/tests/eddsa-poseidon-blake1.test.ts
@@ -359,7 +359,7 @@ describe("EdDSAPoseidon", () => {
     it("Should handle a signature with values smaller than 32 bytes", async () => {
         const signature = signMessage(privateKey, message)
 
-        // S is the only value which we can easily make artifically small, since
+        // S is the only value which we can easily make artificially small, since
         // R8 has to be a point on the curve.
         // Note that overly-large values also ruled out by the inCurve check on
         // R8 and the subOrder check on S.


### PR DESCRIPTION


**Description:**
This pull request corrects a minor typo in a comment within the EdDSA Poseidon Blake1 test file.  
No functional changes were made; this update improves code clarity and documentation.
