### PR TITLE
fix(lean-imt): validate update index range and add out-of-range test

### DIFF
--- a/packages/lean-imt/src/lean-imt.ts
+++ b/packages/lean-imt/src/lean-imt.ts
@@ -207,6 +207,10 @@ export default class LeanIMT<N = bigint> {
         requireDefined(newLeaf, "newLeaf")
         requireNumber(index, "index")
 
+        if (index < 0 || index >= this.size) {
+            throw new Error(`The leaf at index '${index}' does not exist in this tree`)
+        }
+
         let node = newLeaf
 
         for (let level = 0; level < this.depth; level += 1) {

--- a/packages/lean-imt/tests/lean-imt.test.ts
+++ b/packages/lean-imt/tests/lean-imt.test.ts
@@ -209,6 +209,18 @@ describe("Lean IMT", () => {
             expect(tree.root).toBe(poseidon(BigInt(2), BigInt(1)))
         })
 
+        it("Should not update any leaf if the index is out of range", () => {
+            const tree = new LeanIMT(poseidon, leaves)
+
+            const fun1 = () => tree.update(-1, BigInt(1))
+            const fun2 = () => tree.update(tree.size, BigInt(1))
+            const fun3 = () => tree.update(999999, BigInt(1))
+
+            expect(fun1).toThrow("The leaf at index '-1' does not exist in this tree")
+            expect(fun2).toThrow(`The leaf at index '${tree.size}' does not exist in this tree`)
+            expect(fun3).toThrow("The leaf at index '999999' does not exist in this tree")
+        })
+
         it(`Should update ${treeSize} leaves`, () => {
             const tree = new LeanIMT(poseidon, leaves)
 


### PR DESCRIPTION
Add bounds check to LeanIMT.update: throw “The leaf at index '…' does not exist in this tree” when index is out of range.
Add Jest test to assert update throws for out-of-range indices.