### PR TITLE
chore: fix empty array issue in digest function

### DIFF
--- a/packages/lazytower/src/lazytower-hash-chain-proof-builder.ts
+++ b/packages/lazytower/src/lazytower-hash-chain-proof-builder.ts
@@ -38,7 +38,7 @@ export function LazyTowerHashChainProofBuilder(H: number, W: number, hash = defa
     checkParameter(hash, "hash", "function")
 
     const bitsPerLevel = 4
-    const digestFunc = (arr: bigint[]) => arr.reduce(hash)
+    const digestFunc = (arr: bigint[]) => arr.length > 0 ? arr.reduce(hash) : BigInt(0)
     const levels: bigint[][] = []
     const fullLevels: bigint[][] = []
 


### PR DESCRIPTION
## Description

updated `digestFunc` to safely handle empty arrays, preventing errors when building proofs on an empty tower.

## Related Issue(s)

## Other information

## Checklist

-   [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CODE_OF_CONDUCT.md).
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes