### PR TITLE
refactor(smt): make ChildNodes type a comprehensive union of tuples

### DIFF
--- a/packages/smt/src/smt.ts
+++ b/packages/smt/src/smt.ts
@@ -1,5 +1,17 @@
 import { checkHex, getFirstCommonElements, getIndexOfLastNonZeroElement, keyToPath } from "./utils"
-import { ChildNodes, EntryMark, HashFunction, Key, Value, Node, Siblings, EntryResponse, MerkleProof } from "./types"
+import {
+    ChildNodes,
+    EntryMark,
+    HashFunction,
+    Key,
+    Value,
+    Node,
+    Siblings,
+    EntryResponse,
+    MerkleProof,
+    InternalChildNodes,
+    LeafChildNodes
+} from "./types"
 
 /**
  * SparseMerkleTree class provides all the functions to create a sparse Merkle tree
@@ -298,19 +310,19 @@ export default class SMT {
                 if (childNodes[0] === key) {
                     // An entry with the same key was found and
                     // it returns it with the siblings.
-                    return { entry: childNodes, siblings }
+                    return { entry: childNodes as LeafChildNodes, siblings }
                 }
                 // The entry found does not have the same key. But the key of this
                 // particular entry matches the first 'i' bits of the key passed
                 // as parameter and it can be useful in several functions.
-                return { entry: [key], matchingEntry: childNodes, siblings }
+                return { entry: [key], matchingEntry: childNodes as LeafChildNodes, siblings }
             }
 
             // When it goes down into the tree and follows the path, in every step
             // a node is chosen between the left and the right child nodes, and the
             // opposite node is saved as siblings.
-            node = childNodes[direction] as Node
-            siblings.push(childNodes[Number(!direction)] as Node)
+            node = (childNodes as InternalChildNodes)[direction] as Node
+            siblings.push((childNodes as InternalChildNodes)[Number(!direction)] as Node)
         }
 
         // The path led to a zero node.
@@ -326,7 +338,7 @@ export default class SMT {
      */
     private calculateRoot(node: Node, path: number[], siblings: Siblings): Node {
         for (let i = siblings.length - 1; i >= 0; i -= 1) {
-            const childNodes: ChildNodes = path[i] ? [siblings[i], node] : [node, siblings[i]]
+            const childNodes: InternalChildNodes = path[i] ? [siblings[i], node] : [node, siblings[i]]
             node = this.hash(childNodes)
         }
 
@@ -343,7 +355,7 @@ export default class SMT {
      */
     private addNewNodes(node: Node, path: number[], siblings: Siblings, i = siblings.length - 1): Node {
         for (; i >= 0; i -= 1) {
-            const childNodes: ChildNodes = path[i] ? [siblings[i], node] : [node, siblings[i]]
+            const childNodes: InternalChildNodes = path[i] ? [siblings[i], node] : [node, siblings[i]]
             node = this.hash(childNodes)
 
             this.nodes.set(node, childNodes)
@@ -360,7 +372,7 @@ export default class SMT {
      */
     private deleteOldNodes(node: Node, path: number[], siblings: Siblings) {
         for (let i = siblings.length - 1; i >= 0; i -= 1) {
-            const childNodes: ChildNodes = path[i] ? [siblings[i], node] : [node, siblings[i]]
+            const childNodes: InternalChildNodes = path[i] ? [siblings[i], node] : [node, siblings[i]]
             node = this.hash(childNodes)
 
             this.nodes.delete(node)
@@ -373,7 +385,7 @@ export default class SMT {
      * @returns True if the node is a leaf, false otherwise.
      */
     private isLeaf(node: Node): boolean {
-        const childNodes = this.nodes.get(node)
+        const childNodes = this.nodes.get(node) as ChildNodes | undefined
 
         return !!(childNodes && childNodes[2])
     }

--- a/packages/smt/src/types/index.ts
+++ b/packages/smt/src/types/index.ts
@@ -4,14 +4,16 @@ export type Value = Node
 export type EntryMark = Node
 
 export type Entry = [Key, Value, EntryMark]
-export type ChildNodes = Node[]
+export type InternalChildNodes = [Node, Node]
+export type LeafChildNodes = Entry
+export type ChildNodes = InternalChildNodes | LeafChildNodes
 export type Siblings = Node[]
 
-export type HashFunction = (childNodes: ChildNodes) => Node
+export type HashFunction = (childNodes: ChildNodes | [Key]) => Node
 
 export interface EntryResponse {
-    entry: Entry | Node[]
-    matchingEntry?: Entry | Node[]
+    entry: LeafChildNodes | [Key]
+    matchingEntry?: LeafChildNodes
     siblings: Siblings
 }
 

--- a/packages/smt/tests/index.test.ts
+++ b/packages/smt/tests/index.test.ts
@@ -1,32 +1,32 @@
 import { poseidon, smt } from "circomlibjs"
 import sha256 from "crypto-js/sha256"
 import { BarretenbergSync, Fr } from "@aztec/bb.js"
-import { ChildNodes, SMT } from "../src"
+import { HashFunction, SMT } from "../src"
 
 describe("SMT", () => {
-    const hashes = {
-        sha256: (childNodes: ChildNodes) => childNodes.join(""),
-        poseidon2: (childNodes: ChildNodes) => childNodes.join(""),
-        pedersen: (childNodes: ChildNodes) => childNodes.join(""),
-        poseidon: (childNodes: ChildNodes) => childNodes.join("")
+    const hashes: Record<string, HashFunction> = {
+        sha256: (childNodes) => childNodes.join(""),
+        poseidon2: (childNodes) => childNodes.join(""),
+        pedersen: (childNodes) => childNodes.join(""),
+        poseidon: (childNodes) => childNodes.join("")
     }
 
     const testKeys = ["a", "3", "2b", "20", "9", "17"]
 
     beforeAll(async () => {
         const bb = await BarretenbergSync.new()
-        hashes.sha256 = (childNodes: ChildNodes) => sha256(childNodes.join("")).toString()
-        hashes.poseidon2 = (childNodes: ChildNodes) =>
+        hashes.sha256 = (childNodes) => sha256(childNodes.join("")).toString()
+        hashes.poseidon2 = (childNodes) =>
             bb
                 .poseidon2Hash([Fr.fromString(childNodes.join(""))])
                 .toString()
                 .slice(2)
-        hashes.pedersen = (childNodes: ChildNodes) =>
+        hashes.pedersen = (childNodes) =>
             bb
                 .pedersenHash([Fr.fromString(childNodes.join(""))], 0)
                 .toString()
                 .slice(2)
-        hashes.poseidon = (childNodes: ChildNodes) => poseidon(childNodes)
+        hashes.poseidon = (childNodes) => poseidon(childNodes)
     })
 
     describe("Create hexadecimal trees", () => {
@@ -221,7 +221,7 @@ describe("SMT", () => {
             }
 
             const proof = tree.createProof("19")
-            proof.matchingEntry = ["20", "a"]
+            proof.matchingEntry = ["20", "a", "1"]
 
             expect(tree.verifyProof(proof)).toBeFalsy()
         })


### PR DESCRIPTION
## Description
This PR replaces the loose `ChildNodes = Node[]` type with a comprehensive union of precise tuple types that accurately reflect the two distinct node shapes stored in the SMT's internal map:
  - `InternalChildNodes = [Node, Node]`:  parent nodes with exactly two children
  - `LeafChildNodes = Entry ([Key, Value, EntryMark])`:  leaf nodes storing a key/value pair with an entry mark
  - `ChildNodes = InternalChildNodes | LeafChildNodes`: the union

 The test file now uses `Record<string, HashFunction>` for the hashes object to avoid errors from explicit parameter annotations. Also updated `proof.matchingEntry` assignment in the invalid proof test from `["20", "a"]` to `["20", "a", "1"]` to satisfy the`LeafChildNodes` tuple type.

## Related Issue(s)

Closes #342 

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CODE_OF_CONDUCT.md).
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
