### PR TITLE
docs: update URLs from PSE to zk-kit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,7 +29,7 @@
 
 <!-- Please check if the PR fulfills these requirements. -->
 
--   [ ] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CODE_OF_CONDUCT.md).
+-   [ ] I have read and understand the [contributor guidelines](https://github.com/zk-kit/zk-kit/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/zk-kit/zk-kit/blob/main/CODE_OF_CONDUCT.md).
 -   [ ] I have performed a self-review of my code
 -   [ ] I have commented my code, particularly in hard-to-understand areas
 -   [ ] My changes generate no new warnings
@@ -38,4 +38,4 @@
 -   [ ] New and existing unit tests pass locally with my changes
 
 > [!IMPORTANT]
-> We do not accept pull requests for minor grammatical fixes (e.g., correcting typos, rewording sentences) or for fixing broken links, unless they significantly improve clarity or functionality. These contributions, while appreciated, are not a priority for merging. If you notice any of these issues, please create a [GitHub Issue](https://github.com/privacy-scaling-explorations/zk-kit/issues/new?template=BLANK_ISSUE) to report them so they can be properly tracked and addressed.
+> We do not accept pull requests for minor grammatical fixes (e.g., correcting typos, rewording sentences) or for fixing broken links, unless they significantly improve clarity or functionality. These contributions, while appreciated, are not a priority for merging. If you notice any of these issues, please create a [GitHub Issue](https://github.com/zk-kit/zk-kit/issues/new?template=BLANK_ISSUE) to report them so they can be properly tracked and addressed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ We're really glad you're reading this, because we need volunteer developers to h
 
 ## Issues
 
-The best way to contribute to our projects is by opening a [new issue](https://github.com/privacy-scaling-explorations/zk-kit/issues/new/choose) or tackling one of the issues listed [here](https://github.com/privacy-scaling-explorations/zk-kit/contribute).
+The best way to contribute to our projects is by opening a [new issue](https://github.com/zk-kit/zk-kit/issues/new/choose) or tackling one of the issues listed [here](https://github.com/zk-kit/zk-kit/contribute).
 
 ## Pull Requests
 
@@ -34,7 +34,7 @@ Pull requests are great if you want to add a feature or fix a bug. Here's a quic
 > When a new package is created or a new feature is added to the repository, the contributor will be added to the `.github/CODEOWNERS` file to review and approve any future changes to their code.
 
 > [!IMPORTANT]
-> We do not accept pull requests for minor grammatical fixes (e.g., correcting typos, rewording sentences) or for fixing broken links, unless they significantly improve clarity or functionality. These contributions, while appreciated, are not a priority for merging. If you notice any of these issues, please create a [GitHub Issue](https://github.com/privacy-scaling-explorations/zk-kit/issues/new?template=BLANK_ISSUE) to report them so they can be properly tracked and addressed.
+> We do not accept pull requests for minor grammatical fixes (e.g., correcting typos, rewording sentences) or for fixing broken links, unless they significantly improve clarity or functionality. These contributions, while appreciated, are not a priority for merging. If you notice any of these issues, please create a [GitHub Issue](https://github.com/zk-kit/zk-kit/issues/new?template=BLANK_ISSUE) to report them so they can be properly tracked and addressed.
 
 ## CI (Github Actions) Tests
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
 <p align="center">
     <h1 align="center">
       <picture>
-        <source media="(prefers-color-scheme: light)" srcset="https://github.com/privacy-scaling-explorations/zk-kit/assets/11427903/f691c48c-021f-485d-89ef-9ddc8ba74787">
-        <source media="(prefers-color-scheme: dark)" srcset="https://github.com/privacy-scaling-explorations/zk-kit/assets/11427903/f43f4403-846a-48b4-a1fa-0ab234c225e5">
-        <img width="250" alt="ZK-Kit logo" src="https://github.com/privacy-scaling-explorations/zk-kit/assets/11427903/f691c48c-021f-485d-89ef-9ddc8ba74787">
+        <source media="(prefers-color-scheme: light)" srcset="https://github.com/zk-kit/zk-kit/assets/11427903/f691c48c-021f-485d-89ef-9ddc8ba74787">
+        <source media="(prefers-color-scheme: dark)" srcset="https://github.com/zk-kit/zk-kit/assets/11427903/f43f4403-846a-48b4-a1fa-0ab234c225e5">
+        <img width="250" alt="ZK-Kit logo" src="https://github.com/zk-kit/zk-kit/assets/11427903/f691c48c-021f-485d-89ef-9ddc8ba74787">
       </picture>
       <sub>JS</sub>
     </h1>
 </p>
 
 <p align="center">
-    <a href="https://github.com/privacy-scaling-explorations" target="_blank">
+    <a href="https://github.com/zk-kit" target="_blank">
         <img src="https://img.shields.io/badge/project-PSE-blue.svg?style=flat-square">
     </a>
-    <a href="https://github.com/privacy-scaling-explorations/zk-kit/blob/main/LICENSE">
-        <img alt="Github license" src="https://img.shields.io/github/license/privacy-scaling-explorations/zk-kit.svg?style=flat-square">
+    <a href="https://github.com/zk-kit/zk-kit/blob/main/LICENSE">
+        <img alt="Github license" src="https://img.shields.io/github/license/zk-kit/zk-kit.svg?style=flat-square">
     </a>
-    <a href="https://github.com/privacy-scaling-explorations/zk-kit/actions?query=workflow%3Amain">
-        <img alt="GitHub Workflow Tests" src="https://img.shields.io/github/actions/workflow/status/privacy-scaling-explorations/zk-kit/main.yml?branch=main&label=tests&style=flat-square&logo=github">
+    <a href="https://github.com/zk-kit/zk-kit/actions?query=workflow%3Amain">
+        <img alt="GitHub Workflow Tests" src="https://img.shields.io/github/actions/workflow/status/zk-kit/zk-kit/main.yml?branch=main&label=tests&style=flat-square&logo=github">
     </a>
-    <a href="https://coveralls.io/github/privacy-scaling-explorations/zk-kit">
-        <img alt="Coveralls" src="https://img.shields.io/coveralls/github/privacy-scaling-explorations/zk-kit?label=coverage (ts)&style=flat-square&logo=coveralls">
+    <a href="https://coveralls.io/github/zk-kit/zk-kit">
+        <img alt="Coveralls" src="https://img.shields.io/coveralls/github/zk-kit/zk-kit?label=coverage (ts)&style=flat-square&logo=coveralls">
     </a>
     <a href="https://eslint.org/">
         <img alt="Linter eslint" src="https://img.shields.io/badge/linter-eslint-8080f2?style=flat-square&logo=eslint">
@@ -31,8 +31,8 @@
     <a href="http://commitizen.github.io/cz-cli/">
         <img alt="Commitizen friendly" src="https://img.shields.io/badge/commitizen-friendly-586D76?style=flat-square">
     </a>
-    <a href="https://www.gitpoap.io/gh/privacy-scaling-explorations/zk-kit" target="_blank" >
-        <img alt="GitPOAPs" src="https://public-api.gitpoap.io/v1/repo/privacy-scaling-explorations/zk-kit/badge">
+    <a href="https://www.gitpoap.io/gh/zk-kit/zk-kit" target="_blank" >
+        <img alt="GitPOAPs" src="https://public-api.gitpoap.io/v1/repo/zk-kit/zk-kit/badge">
     </a>
 </p>
 
@@ -46,7 +46,7 @@
             🤝 Code of conduct
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
-        <a href="https://github.com/privacy-scaling-explorations/zk-kit/issues/new/choose">
+        <a href="https://github.com/zk-kit/zk-kit/issues/new/choose">
             🔎 Issues
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
@@ -69,15 +69,15 @@
 
 ## 🗂️ Repositories
 
--   Circom: [privacy-scaling-explorations/zk-kit.circom](https://github.com/privacy-scaling-explorations/zk-kit.circom)
--   Javascript: [privacy-scaling-explorations/zk-kit](https://github.com/privacy-scaling-explorations/zk-kit)
--   Noir: [privacy-scaling-explorations/zk-kit.noir](https://github.com/privacy-scaling-explorations/zk-kit.noir)
--   Rust: [privacy-scaling-explorations/zk-kit.rust](https://github.com/privacy-scaling-explorations/zk-kit.rust)
--   Solidity: [privacy-scaling-explorations/zk-kit.solidity](https://github.com/privacy-scaling-explorations/zk-kit.solidity)
+-   Circom: [zk-kit/zk-kit.circom](https://github.com/zk-kit/zk-kit.circom)
+-   Javascript: [zk-kit/zk-kit](https://github.com/zk-kit/zk-kit)
+-   Noir: [zk-kit/zk-kit.noir](https://github.com/zk-kit/zk-kit.noir)
+-   Rust: [zk-kit/zk-kit.rust](https://github.com/zk-kit/zk-kit.rust)
+-   Solidity: [zk-kit/zk-kit.solidity](https://github.com/zk-kit/zk-kit.solidity)
 
 ## 📄 Papers
 
--   LeanIMT ([Download PDF](https://github.com/privacy-scaling-explorations/zk-kit/raw/main/papers/leanimt/paper/leanimt-paper.pdf))
+-   LeanIMT ([Download PDF](https://github.com/zk-kit/zk-kit/raw/main/papers/leanimt/paper/leanimt-paper.pdf))
 
 ## 📦 Packages
 
@@ -90,7 +90,7 @@
     <tbody>
         <tr>
             <td>
-                <a href="https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/eddsa-poseidon">
+                <a href="https://github.com/zk-kit/zk-kit/tree/main/packages/eddsa-poseidon">
                     @zk-kit/eddsa-poseidon
                 </a>
             </td>
@@ -120,7 +120,7 @@
         </tr>
         <tr>
             <td>
-                <a href="https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/poseidon-cipher">
+                <a href="https://github.com/zk-kit/zk-kit/tree/main/packages/poseidon-cipher">
                     @zk-kit/poseidon-cipher
                 </a>
             </td>
@@ -148,7 +148,7 @@
         </tr>
         <tr>
             <td>
-                <a href="https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/baby-jubjub">
+                <a href="https://github.com/zk-kit/zk-kit/tree/main/packages/baby-jubjub">
                     @zk-kit/baby-jubjub
                 </a>
             </td>
@@ -178,7 +178,7 @@
         </tr>
         <tr>
             <td>
-                <a href="https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/utils">
+                <a href="https://github.com/zk-kit/zk-kit/tree/main/packages/utils">
                     @zk-kit/utils
                 </a>
             </td>
@@ -208,7 +208,7 @@
         </tr>
         <tr>
             <td>
-                <a href="https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/imt">
+                <a href="https://github.com/zk-kit/zk-kit/tree/main/packages/imt">
                     @zk-kit/imt
                 </a>
             </td>
@@ -236,7 +236,7 @@
         </tr>
         <tr>
             <td>
-                <a href="https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/lean-imt">
+                <a href="https://github.com/zk-kit/zk-kit/tree/main/packages/lean-imt">
                     @zk-kit/lean-imt
                 </a>
             </td>
@@ -266,7 +266,7 @@
         </tr>
         <tr>
             <td>
-                <a href="https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/smt">
+                <a href="https://github.com/zk-kit/zk-kit/tree/main/packages/smt">
                     @zk-kit/smt
                 </a>
             </td>
@@ -294,7 +294,7 @@
         </tr>
         <tr>
             <td>
-                <a href="https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/poseidon-proof">
+                <a href="https://github.com/zk-kit/zk-kit/tree/main/packages/poseidon-proof">
                     @zk-kit/poseidon-proof
                 </a>
             </td>
@@ -322,7 +322,7 @@
         </tr>
         <tr>
             <td>
-                <a href="https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/logical-expressions">
+                <a href="https://github.com/zk-kit/zk-kit/tree/main/packages/logical-expressions">
                     @zk-kit/logical-expressions
                 </a>
             </td>
@@ -353,17 +353,17 @@
 
 ## 👥 Ways to contribute
 
--   🔧 Work on [open issues](https://github.com/privacy-scaling-explorations/zk-kit/contribute)
--   📦 Suggest new [packages](https://github.com/privacy-scaling-explorations/zk-kit/issues/new?assignees=&labels=feature+%3Arocket%3A&template=---package.md&title=)
--   🚀 Share ideas for new [features](https://github.com/privacy-scaling-explorations/zk-kit/issues/new?assignees=&labels=feature+%3Arocket%3A&template=---feature.md&title=)
--   🐛 Create a report if you find any [bugs](https://github.com/privacy-scaling-explorations/zk-kit/issues/new?assignees=&labels=bug+%F0%9F%90%9B&template=---bug.md&title=) in the code
+-   🔧 Work on [open issues](https://github.com/zk-kit/zk-kit/contribute)
+-   📦 Suggest new [packages](https://github.com/zk-kit/zk-kit/issues/new?assignees=&labels=feature+%3Arocket%3A&template=---package.md&title=)
+-   🚀 Share ideas for new [features](https://github.com/zk-kit/zk-kit/issues/new?assignees=&labels=feature+%3Arocket%3A&template=---feature.md&title=)
+-   🐛 Create a report if you find any [bugs](https://github.com/zk-kit/zk-kit/issues/new?assignees=&labels=bug+%F0%9F%90%9B&template=---bug.md&title=) in the code
 
 ## 🛠 Install
 
 Clone this repository:
 
 ```bash
-git clone https://github.com/privacy-scaling-explorations/zk-kit.git
+git clone https://github.com/zk-kit/zk-kit.git
 ```
 
 and install the dependencies:
@@ -475,7 +475,7 @@ grep -r -l "smt" . | xargs sed -i 's/smt/my-package/'
 # Update the remaining description/usage sections, and write your code in the src & tests folders!
 ```
 
-3. Create an [issue](https://github.com/privacy-scaling-explorations/zk-kit/issues/new?assignees=&labels=feature+%3Arocket%3A&template=---package.md&title=) for your package and open a PR.
+3. Create an [issue](https://github.com/zk-kit/zk-kit/issues/new?assignees=&labels=feature+%3Arocket%3A&template=---package.md&title=) for your package and open a PR.
 
 #### How can I create benchmarks for my library?
 
@@ -489,11 +489,11 @@ You can see some examples in the `benchmarks` folder. All you have to do is crea
 
 **Sparse:** Particularly useful when you need proof of non-membership.
 
-| Type                 | Library Name                                                                                           | Main Feature                            | Used by                                                                                                                 |
-| -------------------- | ------------------------------------------------------------------------------------------------------ | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| **Incremental**      | [@zk-kit/imt](https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/imt)           | Fastest for incremental updates.        | [Semaphore V3](https://github.com/semaphore-protocol/semaphore/tree/v3.15.2), [Worldcoin](https://github.com/worldcoin) |
-| **Lean Incremental** | [@zk-kit/lean-imt](https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/lean-imt) | Optimized for lightweight environments. | [Semaphore V4](https://github.com/semaphore-protocol/semaphore), [Zupass](https://github.com/proofcarryingdata/zupass)  |
-| **Sparse**           | [@zk-kit/smt](https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/smt)           | Handles very large sets efficiently.    | [Iden3](https://github.com/iden3)                                                                                       |
+| Type                 | Library Name                                                                     | Main Feature                            | Used by                                                                                                                 |
+| -------------------- | -------------------------------------------------------------------------------- | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| **Incremental**      | [@zk-kit/imt](https://github.com/zk-kit/zk-kit/tree/main/packages/imt)           | Fastest for incremental updates.        | [Semaphore V3](https://github.com/semaphore-protocol/semaphore/tree/v3.15.2), [Worldcoin](https://github.com/worldcoin) |
+| **Lean Incremental** | [@zk-kit/lean-imt](https://github.com/zk-kit/zk-kit/tree/main/packages/lean-imt) | Optimized for lightweight environments. | [Semaphore V4](https://github.com/semaphore-protocol/semaphore), [Zupass](https://github.com/proofcarryingdata/zupass)  |
+| **Sparse**           | [@zk-kit/smt](https://github.com/zk-kit/zk-kit/tree/main/packages/smt)           | Handles very large sets efficiently.    | [Iden3](https://github.com/iden3)                                                                                       |
 
 Following benchmarks data of zk-kit Merkle Trees implementations:
 |8 leafs|insert|delete|update|generate proof|verify proof|

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -24,7 +24,7 @@ Before running the benchmark, ensure that you have Node.js version 20 installed 
 
 1. **Clone the Repository**:
     ```bash
-    git clone https://github.com/privacy-scaling-explorations/zk-kit.git
+    git clone https://github.com/zk-kit/zk-kit.git
     cd zk-kit
     yarn
     ```
@@ -80,7 +80,7 @@ Fastest is IMT - Generated 500 proofs
 ```
 
 The Benchmarks suggested in the index.ts are for **8, 128 and 1024 leaves** to see how each Merkle tree for different sizes of trees
-perform because their theoretical expected behavior described [here](https://github.com/privacy-scaling-explorations/zk-kit?tab=readme-ov-file#i-need-to-use-a-merkle-tree-to-prove-the-inclusion-or-exclusion-of-data-elements-within-a-set-which-type-of-merkle-tree-should-i-use).
+perform because their theoretical expected behavior described [here](https://github.com/zk-kit/zk-kit?tab=readme-ov-file#i-need-to-use-a-merkle-tree-to-prove-the-inclusion-or-exclusion-of-data-elements-within-a-set-which-type-of-merkle-tree-should-i-use).
 
 ## Dependencies
 

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
     "name": "zk-kit",
     "description": "A monorepo of reusable JS libraries for zero-knowledge technologies.",
     "license": "MIT",
-    "repository": "git@github.com:privacy-scaling-explorations/zk-kit.git",
-    "homepage": "https://github.com/privacy-scaling-explorations/zk-kit",
-    "bugs": "https://github.com/privacy-scaling-explorations/zk-kit/issues",
+    "repository": "git@github.com:zk-kit/zk-kit.git",
+    "homepage": "https://github.com/zk-kit/zk-kit",
+    "bugs": "https://github.com/zk-kit/zk-kit/issues",
     "private": true,
     "scripts": {
         "_build": "yarn workspaces foreach -A -t --no-private run build",

--- a/packages/baby-jubjub/README.md
+++ b/packages/baby-jubjub/README.md
@@ -6,10 +6,10 @@
 </p>
 
 <p align="center">
-    <a href="https://github.com/privacy-scaling-explorations/zk-kit">
+    <a href="https://github.com/zk-kit/zk-kit">
         <img src="https://img.shields.io/badge/project-zk--kit-blue.svg?style=flat-square">
     </a>
-    <a href="https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/baby-jubjub/LICENSE">
+    <a href="https://github.com/zk-kit/zk-kit/tree/main/packages/baby-jubjub/LICENSE">
         <img alt="NPM license" src="https://img.shields.io/npm/l/%40zk-kit%2Fbaby-jubjub?style=flat-square">
     </a>
     <a href="https://www.npmjs.com/package/@zk-kit/baby-jubjub">

--- a/packages/baby-jubjub/package.json
+++ b/packages/baby-jubjub/package.json
@@ -22,10 +22,10 @@
         "LICENSE",
         "README.md"
     ],
-    "repository": "git@github.com:privacy-scaling-explorations/zk-kit.git",
-    "homepage": "https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/baby-jubjub",
+    "repository": "git@github.com:zk-kit/zk-kit.git",
+    "homepage": "https://github.com/zk-kit/zk-kit/tree/main/packages/baby-jubjub",
     "bugs": {
-        "url": "https://github.com/privacy-scaling-explorations/zk-kit.git/issues"
+        "url": "https://github.com/zk-kit/zk-kit.git/issues"
     },
     "scripts": {
         "build": "rimraf dist && rollup -c rollup.config.ts --configPlugin typescript",

--- a/packages/eddsa-poseidon/README.md
+++ b/packages/eddsa-poseidon/README.md
@@ -6,10 +6,10 @@
 </p>
 
 <p align="center">
-    <a href="https://github.com/privacy-scaling-explorations/zk-kit">
+    <a href="https://github.com/zk-kit/zk-kit">
         <img src="https://img.shields.io/badge/project-zk--kit-blue.svg?style=flat-square">
     </a>
-    <a href="https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/eddsa-poseidon/LICENSE">
+    <a href="https://github.com/zk-kit/zk-kit/tree/main/packages/eddsa-poseidon/LICENSE">
         <img alt="NPM license" src="https://img.shields.io/npm/l/%40zk-kit%2Feddsa-poseidon?style=flat-square">
     </a>
     <a href="https://www.npmjs.com/package/@zk-kit/eddsa-poseidon">

--- a/packages/eddsa-poseidon/package.json
+++ b/packages/eddsa-poseidon/package.json
@@ -32,10 +32,10 @@
         "LICENSE",
         "README.md"
     ],
-    "repository": "git@github.com:privacy-scaling-explorations/zk-kit.git",
-    "homepage": "https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/eddsa-poseidon",
+    "repository": "git@github.com:zk-kit/zk-kit.git",
+    "homepage": "https://github.com/zk-kit/zk-kit/tree/main/packages/eddsa-poseidon",
     "bugs": {
-        "url": "https://github.com/privacy-scaling-explorations/zk-kit.git/issues"
+        "url": "https://github.com/zk-kit/zk-kit.git/issues"
     },
     "scripts": {
         "build": "rimraf dist && rollup -c rollup.config.ts --configPlugin typescript",

--- a/packages/imt/README.md
+++ b/packages/imt/README.md
@@ -6,10 +6,10 @@
 </p>
 
 <p align="center">
-    <a href="https://github.com/privacy-scaling-explorations/zk-kit">
+    <a href="https://github.com/zk-kit/zk-kit">
         <img src="https://img.shields.io/badge/project-zk--kit-blue.svg?style=flat-square">
     </a>
-    <a href="https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/imt/LICENSE">
+    <a href="https://github.com/zk-kit/zk-kit/tree/main/packages/imt/LICENSE">
         <img alt="NPM license" src="https://img.shields.io/npm/l/%40zk-kit%2Fimt?style=flat-square">
     </a>
     <a href="https://www.npmjs.com/package/@zk-kit/imt">
@@ -38,7 +38,7 @@
 </div>
 
 > [!WARNING]  
-> If you are looking for the first version of this package, please visit this [link](https://github.com/privacy-scaling-explorations/zk-kit/tree/imt-v1/packages/incremental-merkle-tree).
+> If you are looking for the first version of this package, please visit this [link](https://github.com/zk-kit/zk-kit/tree/imt-v1/packages/incremental-merkle-tree).
 
 In this implementation, the tree is built with a predetermined depth, utilizing a list of zeros (one for each level) to hash nodes lacking fully defined children. The tree's branching factor, or the number of children per node, can be customized via the arity parameter.
 

--- a/packages/imt/package.json
+++ b/packages/imt/package.json
@@ -22,10 +22,10 @@
         "LICENSE",
         "README.md"
     ],
-    "repository": "git@github.com:privacy-scaling-explorations/zk-kit.git",
-    "homepage": "https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/imt",
+    "repository": "git@github.com:zk-kit/zk-kit.git",
+    "homepage": "https://github.com/zk-kit/zk-kit/tree/main/packages/imt",
     "bugs": {
-        "url": "https://github.com/privacy-scaling-explorations/zk-kit.git/issues"
+        "url": "https://github.com/zk-kit/zk-kit.git/issues"
     },
     "scripts": {
         "build": "rimraf dist && rollup -c rollup.config.ts --configPlugin typescript",

--- a/packages/lazytower/README.md
+++ b/packages/lazytower/README.md
@@ -6,10 +6,10 @@
 </p>
 
 <p align="center">
-    <a href="https://github.com/privacy-scaling-explorations/zk-kit">
+    <a href="https://github.com/zk-kit/zk-kit">
         <img src="https://img.shields.io/badge/project-zk--kit-blue.svg?style=flat-square">
     </a>
-    <a href="https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/lazytower/LICENSE">
+    <a href="https://github.com/zk-kit/zk-kit/tree/main/packages/lazytower/LICENSE">
         <img alt="NPM license" src="https://img.shields.io/npm/l/%40zk-kit%2Flazytower?style=flat-square">
     </a>
     <a href="https://www.npmjs.com/package/@zk-kit/lazytower">

--- a/packages/lazytower/package.json
+++ b/packages/lazytower/package.json
@@ -22,8 +22,8 @@
         "README.md",
         "LICENSE"
     ],
-    "repository": "git@github.com:privacy-scaling-explorations/zk-kit.git",
-    "homepage": "https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/lazytower",
+    "repository": "git@github.com:zk-kit/zk-kit.git",
+    "homepage": "https://github.com/zk-kit/zk-kit/tree/main/packages/lazytower",
     "author": {
         "name": "LCamel",
         "email": "lcamel@gmail.com",

--- a/packages/lean-imt/README.md
+++ b/packages/lean-imt/README.md
@@ -6,10 +6,10 @@
 </p>
 
 <p align="center">
-    <a href="https://github.com/privacy-scaling-explorations/zk-kit">
+    <a href="https://github.com/zk-kit/zk-kit">
         <img src="https://img.shields.io/badge/project-zk--kit-blue.svg?style=flat-square">
     </a>
-    <a href="https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/lean-imt/LICENSE">
+    <a href="https://github.com/zk-kit/zk-kit/tree/main/packages/lean-imt/LICENSE">
         <img alt="NPM license" src="https://img.shields.io/npm/l/%40zk-kit%2Flean-imt?style=flat-square">
     </a>
     <a href="https://www.npmjs.com/package/@zk-kit/lean-imt">
@@ -40,7 +40,7 @@
 > [!NOTE]  
 > This library has been audited as part of the Semaphore V4 PSE audit: https://semaphore.pse.dev/Semaphore_4.0.0_Audit.pdf.
 
-The LeanIMT is an optimized binary version of the [IMT](https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/imt) into binary-focused model, eliminating the need for zero values and allowing dynamic depth adjustment. Unlike the IMT, which uses a zero hash for incomplete nodes, the LeanIMT directly adopts the left child's value when a node lacks a right counterpart. The tree's depth dynamically adjusts to the count of leaves, enhancing efficiency by reducing the number of required hash calculations. To understand more about the LeanIMT, check out the [paper](https://github.com/privacy-scaling-explorations/zk-kit/tree/main/papers/leanimt).
+The LeanIMT is an optimized binary version of the [IMT](https://github.com/zk-kit/zk-kit/tree/main/packages/imt) into binary-focused model, eliminating the need for zero values and allowing dynamic depth adjustment. Unlike the IMT, which uses a zero hash for incomplete nodes, the LeanIMT directly adopts the left child's value when a node lacks a right counterpart. The tree's depth dynamically adjusts to the count of leaves, enhancing efficiency by reducing the number of required hash calculations. To understand more about the LeanIMT, check out the [paper](https://github.com/zk-kit/zk-kit/tree/main/papers/leanimt).
 
 ---
 

--- a/packages/lean-imt/package.json
+++ b/packages/lean-imt/package.json
@@ -22,10 +22,10 @@
         "LICENSE",
         "README.md"
     ],
-    "repository": "git@github.com:privacy-scaling-explorations/zk-kit.git",
-    "homepage": "https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/lean-imt",
+    "repository": "git@github.com:zk-kit/zk-kit.git",
+    "homepage": "https://github.com/zk-kit/zk-kit/tree/main/packages/lean-imt",
     "bugs": {
-        "url": "https://github.com/privacy-scaling-explorations/zk-kit.git/issues"
+        "url": "https://github.com/zk-kit/zk-kit.git/issues"
     },
     "scripts": {
         "build": "rimraf dist && rollup -c rollup.config.ts --configPlugin typescript",

--- a/packages/logical-expressions/README.md
+++ b/packages/logical-expressions/README.md
@@ -6,10 +6,10 @@
 </p>
 
 <p align="center">
-    <a href="https://github.com/privacy-scaling-explorations/zk-kit">
+    <a href="https://github.com/zk-kit/zk-kit">
         <img src="https://img.shields.io/badge/project-zk--kit-blue.svg?style=flat-square">
     </a>
-    <a href="https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/logical-expressions/LICENSE">
+    <a href="https://github.com/zk-kit/zk-kit/tree/main/packages/logical-expressions/LICENSE">
         <img alt="NPM license" src="https://img.shields.io/npm/l/%40zk-kit%2Flogical-expressions?style=flat-square">
     </a>
     <a href="https://www.npmjs.com/package/@zk-kit/logical-expressions">

--- a/packages/logical-expressions/package.json
+++ b/packages/logical-expressions/package.json
@@ -17,10 +17,10 @@
         "dist/",
         "src/"
     ],
-    "repository": "git@github.com:privacy-scaling-explorations/zk-kit.git",
-    "homepage": "https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/logical-expressions",
+    "repository": "git@github.com:zk-kit/zk-kit.git",
+    "homepage": "https://github.com/zk-kit/zk-kit/tree/main/packages/logical-expressions",
     "bugs": {
-        "url": "https://github.com/privacy-scaling-explorations/zk-kit.git/issues"
+        "url": "https://github.com/zk-kit/zk-kit.git/issues"
     },
     "author": {
         "name": "Vivian Plasencia",

--- a/packages/poseidon-cipher/README.md
+++ b/packages/poseidon-cipher/README.md
@@ -6,10 +6,10 @@
 </p>
 
 <p align="center">
-    <a href="https://github.com/privacy-scaling-explorations/zk-kit">
+    <a href="https://github.com/zk-kit/zk-kit">
         <img src="https://img.shields.io/badge/project-zk--kit-blue.svg?style=flat-square">
     </a>
-    <a href="https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/poseidon-cipher/LICENSE">
+    <a href="https://github.com/zk-kit/zk-kit/tree/main/packages/poseidon-cipher/LICENSE">
         <img alt="NPM license" src="https://img.shields.io/npm/l/%40zk-kit%2Fposeidon-cipher?style=flat-square">
     </a>
     <a href="https://www.npmjs.com/package/@zk-kit/poseidon-cipher">
@@ -29,7 +29,7 @@
     </a>
 </p>
 
-> ⚠️ **SECURITY WARNING**: This implementation uses JavaScript's native `BigInt` which is [not constant-time](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#cryptography) and may be vulnerable to timing attacks. If your application requires protection against timing attacks, consider using a constant-time cryptographic library instead. This issue is tracked in [GitHub issue #341](https://github.com/privacy-scaling-explorations/zk-kit/issues/341).
+> ⚠️ **SECURITY WARNING**: This implementation uses JavaScript's native `BigInt` which is [not constant-time](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#cryptography) and may be vulnerable to timing attacks. If your application requires protection against timing attacks, consider using a constant-time cryptographic library instead. This issue is tracked in [GitHub issue #341](https://github.com/zk-kit/zk-kit/issues/341).
 
 <div align="center">
     <h4>

--- a/packages/poseidon-cipher/package.json
+++ b/packages/poseidon-cipher/package.json
@@ -31,8 +31,8 @@
         "README.md",
         "LICENSE"
     ],
-    "repository": "git@github.com:privacy-scaling-explorations/zk-kit.git",
-    "homepage": "https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/poseidon-cipher",
+    "repository": "git@github.com:zk-kit/zk-kit.git",
+    "homepage": "https://github.com/zk-kit/zk-kit/tree/main/packages/poseidon-cipher",
     "scripts": {
         "build": "rimraf dist && rollup -c rollup.config.ts --configPlugin typescript",
         "prepublishOnly": "yarn build"

--- a/packages/poseidon-cipher/src/poseidonCipher.ts
+++ b/packages/poseidon-cipher/src/poseidonCipher.ts
@@ -14,7 +14,7 @@ import { CipherText, EncryptionKey, Nonce, PlainText } from "./types"
  * and may be vulnerable to timing attacks. If your application requires protection against timing attacks,
  * consider using a constant-time cryptographic library instead.
  * See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#cryptography
- * This issue is tracked in GitHub issue #341: https://github.com/privacy-scaling-explorations/zk-kit/issues/341
+ * This issue is tracked in GitHub issue #341: https://github.com/zk-kit/zk-kit/issues/341
  */
 
 /**

--- a/packages/poseidon-proof/README.md
+++ b/packages/poseidon-proof/README.md
@@ -6,10 +6,10 @@
 </p>
 
 <p align="center">
-    <a href="https://github.com/privacy-scaling-explorations/zk-kit">
+    <a href="https://github.com/zk-kit/zk-kit">
         <img src="https://img.shields.io/badge/project-zk--kit-blue.svg?style=flat-square">
     </a>
-    <a href="https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/poseidon-proof/LICENSE">
+    <a href="https://github.com/zk-kit/zk-kit/tree/main/packages/poseidon-proof/LICENSE">
         <img alt="NPM license" src="https://img.shields.io/npm/l/%40zk-kit%2Fposeidon-proof?style=flat-square">
     </a>
     <a href="https://www.npmjs.com/package/@zk-kit/poseidon-proof">
@@ -37,8 +37,8 @@
     </h4>
 </div>
 
-| This zero-knowledge library facilitates the demonstration of having a Poseidon hash pre-image while keeping the pre-image value confidential. Additionally, it offers a mechanism to prevent the same proof from being reused. The circuit that forms the foundation of this library is accessible via this [link](https://github.com/privacy-scaling-explorations/zk-kit.circom/blob/main/packages/poseidon-proof/src/poseidon-proof.circom). |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| This zero-knowledge library facilitates the demonstration of having a Poseidon hash pre-image while keeping the pre-image value confidential. Additionally, it offers a mechanism to prevent the same proof from being reused. The circuit that forms the foundation of this library is accessible via this [link](https://github.com/zk-kit/zk-kit.circom/blob/main/packages/poseidon-proof/src/poseidon-proof.circom). |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 
 Originally developed for integration with [Semaphore V4](https://github.com/semaphore-protocol/semaphore), this library also functions effectively as a standalone tool. Notable use cases in connection with Semaphore can be:
 

--- a/packages/poseidon-proof/package.json
+++ b/packages/poseidon-proof/package.json
@@ -19,10 +19,10 @@
         "LICENSE",
         "README.md"
     ],
-    "repository": "git@github.com:privacy-scaling-explorations/zk-kit.git",
-    "homepage": "https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/poseidon-proof",
+    "repository": "git@github.com:zk-kit/zk-kit.git",
+    "homepage": "https://github.com/zk-kit/zk-kit/tree/main/packages/poseidon-proof",
     "bugs": {
-        "url": "https://github.com/privacy-scaling-explorations/zk-kit.git/issues"
+        "url": "https://github.com/zk-kit/zk-kit.git/issues"
     },
     "scripts": {
         "build": "rimraf dist && rollup -c rollup.config.ts --configPlugin typescript",

--- a/packages/smt/README.md
+++ b/packages/smt/README.md
@@ -6,10 +6,10 @@
 </p>
 
 <p align="center">
-    <a href="https://github.com/privacy-scaling-explorations/zk-kit">
+    <a href="https://github.com/zk-kit/zk-kit">
         <img src="https://img.shields.io/badge/project-zk--kit-blue.svg?style=flat-square">
     </a>
-    <a href="https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/smt/LICENSE">
+    <a href="https://github.com/zk-kit/zk-kit/tree/main/packages/smt/LICENSE">
         <img alt="NPM license" src="https://img.shields.io/npm/l/%40zk-kit%2Fsmt?style=flat-square">
     </a>
     <a href="https://www.npmjs.com/package/@zk-kit/smt">

--- a/packages/smt/package.json
+++ b/packages/smt/package.json
@@ -27,8 +27,8 @@
         "README.md",
         "LICENSE"
     ],
-    "repository": "git@github.com:privacy-scaling-explorations/zk-kit.git",
-    "homepage": "https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/smt",
+    "repository": "git@github.com:zk-kit/zk-kit.git",
+    "homepage": "https://github.com/zk-kit/zk-kit/tree/main/packages/smt",
     "author": {
         "name": "Cedoor",
         "email": "me@cedoor.dev",

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -6,10 +6,10 @@
 </p>
 
 <p align="center">
-    <a href="https://github.com/privacy-scaling-explorations/zk-kit">
+    <a href="https://github.com/zk-kit/zk-kit">
         <img src="https://img.shields.io/badge/project-zk--kit-blue.svg?style=flat-square">
     </a>
-    <a href="https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/utils/LICENSE">
+    <a href="https://github.com/zk-kit/zk-kit/tree/main/packages/utils/LICENSE">
         <img alt="NPM license" src="https://img.shields.io/npm/l/%40zk-kit%2Futils?style=flat-square">
     </a>
     <a href="https://www.npmjs.com/package/@zk-kit/utils">

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -56,10 +56,10 @@
         "LICENSE",
         "README.md"
     ],
-    "repository": "git@github.com:privacy-scaling-explorations/zk-kit.git",
-    "homepage": "https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/utils",
+    "repository": "git@github.com:zk-kit/zk-kit.git",
+    "homepage": "https://github.com/zk-kit/zk-kit/tree/main/packages/utils",
     "bugs": {
-        "url": "https://github.com/privacy-scaling-explorations/zk-kit.git/issues"
+        "url": "https://github.com/zk-kit/zk-kit.git/issues"
     },
     "scripts": {
         "build": "rimraf dist && rollup -c rollup.config.ts --configPlugin typescript",

--- a/papers/leanimt/README.md
+++ b/papers/leanimt/README.md
@@ -1,6 +1,6 @@
 # LeanIMT Paper
 
-This folder contains the LeanIMT Paper ([Download PDF](https://github.com/privacy-scaling-explorations/zk-kit/raw/main/papers/leanimt/paper/leanimt-paper.pdf)).
+This folder contains the LeanIMT Paper ([Download PDF](https://github.com/zk-kit/zk-kit/raw/main/papers/leanimt/paper/leanimt-paper.pdf)).
 
 ## Related work
 
@@ -10,9 +10,9 @@ This folder contains the LeanIMT Paper ([Download PDF](https://github.com/privac
 
 ## Code
 
--   LeanIMT TypeScript implementation: https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/lean-imt.
+-   LeanIMT TypeScript implementation: https://github.com/zk-kit/zk-kit/tree/main/packages/lean-imt.
 
--   LeanIMT Solidity implementation: https://github.com/privacy-scaling-explorations/zk-kit.solidity/tree/main/packages/lean-imt.
+-   LeanIMT Solidity implementation: https://github.com/zk-kit/zk-kit.solidity/tree/main/packages/lean-imt.
 
 ## Install Latex to work with VSCode on Mac
 

--- a/papers/leanimt/paper/leanimt-paper.tex
+++ b/papers/leanimt/paper/leanimt-paper.tex
@@ -1090,12 +1090,12 @@ The TypeScript/JavaScript and Solidity code of the LeanIMT was audited as part o
 
 \subsection{TypeScript/JavaScript}
 
-TypeScript/JavaScript LeanIMT code: \url{https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/lean-imt}
+TypeScript/JavaScript LeanIMT code: \url{https://github.com/zk-kit/zk-kit/tree/main/packages/lean-imt}
 
 
 \subsection{Solidity}
 
-Solidity LeanIMT code: \url{https://github.com/privacy-scaling-explorations/zk-kit.solidity/tree/main/packages/lean-imt}
+Solidity LeanIMT code: \url{https://github.com/zk-kit/zk-kit.solidity/tree/main/packages/lean-imt}
 
 
 \section{Benchmarks}
@@ -1127,7 +1127,7 @@ GitHub repository to run Node.js and browser benchmarks: \url{https://github.com
 
 \textbf{Solidity}
 
-GitHub repository to run Solidity benchmarks: \url{https://github.com/privacy-scaling-explorations/zk-kit.solidity}
+GitHub repository to run Solidity benchmarks: \url{https://github.com/zk-kit/zk-kit.solidity}
 
 
 \subsection{TypeScript/JavaScript}

--- a/papers/leanimt/paper/references.bib
+++ b/papers/leanimt/paper/references.bib
@@ -33,12 +33,12 @@
 
 @misc{imt_typescript,
   title = {IMT TypeScript implementation},
-  url   = {https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/imt}
+  url   = {https://github.com/zk-kit/zk-kit/tree/main/packages/imt}
 }
 
 @misc{imt_solidity,
   title = {IMT Solidity implementation},
-  url   = {https://github.com/privacy-scaling-explorations/zk-kit.solidity/tree/main/packages/imt}
+  url   = {https://github.com/zk-kit/zk-kit.solidity/tree/main/packages/imt}
 }
 
 @misc{zero_knowledge_definition,
@@ -94,10 +94,10 @@
 
 @misc{lazy_tower_typescript,
   title = {LazyTower TypeScript implementation},
-  url   = {https://github.com/privacy-scaling-explorations/zk-kit/tree/main/packages/lazytower}
+  url   = {https://github.com/zk-kit/zk-kit/tree/main/packages/lazytower}
 }
 
 @misc{lazy_tower_solidity,
   title = {LazyTower Solidity implementation},
-  url   = {https://github.com/privacy-scaling-explorations/zk-kit.solidity/tree/main/packages/lazytower}
+  url   = {https://github.com/zk-kit/zk-kit.solidity/tree/main/packages/lazytower}
 }


### PR DESCRIPTION

## Description

This PR updated all GitHub organization URLs from `privacy-scaling-explorations` to `zk-kit` including the LeanIMT paper, contribution docs adn more

## Related Issue(s)

Closes #401 
## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CODE_OF_CONDUCT.md).
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
