### PR TITLE
chore: fix TypeDoc warnings

### DIFF
--- a/packages/eddsa-poseidon/typedoc.json
+++ b/packages/eddsa-poseidon/typedoc.json
@@ -1,3 +1,4 @@
 {
-    "entryPoints": ["src/index.ts"]
+    "entryPoints": ["src/index.ts"],
+    "intentionallyNotExported": ["eddsa-poseidon-factory.ts:EdDSAPoseidon"]
 }

--- a/packages/imt/src/imt.ts
+++ b/packages/imt/src/imt.ts
@@ -108,7 +108,7 @@ export default class IMT {
     /**
      * The root of the tree. This value doesn't need to be stored as
      * it is always the first and unique element of the last level of the tree.
-     * Its value can be retrieved in {@link IMT#_nodes}.
+     * Its value can be retrieved in `_nodes`.
      * @returns The root hash of the tree.
      */
     public get root(): IMTNode {
@@ -125,7 +125,7 @@ export default class IMT {
 
     /**
      * The leaves of the tree. They can be retrieved from the first
-     * level of the tree using {@link IMT#_nodes}. The returned
+     * level of the tree using `_nodes`. The returned
      * value is a copy of the array and not the original object.
      * @returns The list of tree leaves.
      */

--- a/packages/lean-imt/src/lean-imt.ts
+++ b/packages/lean-imt/src/lean-imt.ts
@@ -8,7 +8,7 @@ import {
 import { LeanIMTHashFunction, LeanIMTMerkleProof } from "./types"
 
 /**
- * The {@link LeanIMT} is an optimized binary version of the {@link IMT}.
+ * The {@link LeanIMT} is an optimized binary version of the IMT (Incremental Merkle Tree).
  * This implementation exclusively supports binary trees, eliminates the use of
  * zeroes, and the tree's {@link LeanIMT#depth} is dynamic. When a node doesn't have the right child,
  * instead of using a zero hash as in the IMT, the node's value becomes that
@@ -54,7 +54,7 @@ export default class LeanIMT<N = bigint> {
     /**
      * The root of the tree. This value doesn't need to be stored as
      * it is always the first and unique element of the last level of the tree.
-     * Its value can be retrieved in {@link LeanIMT#_nodes}.
+     * Its value can be retrieved in `_nodes`.
      * @returns The root hash of the tree.
      */
     public get root(): N {
@@ -71,7 +71,7 @@ export default class LeanIMT<N = bigint> {
 
     /**
      * The leaves of the tree. They can be retrieved from the first
-     * level of the tree using {@link LeanIMT#_nodes}. The returned
+     * level of the tree using `_nodes`. The returned
      * value is a copy of the array and not the original object.
      * @returns The list of tree leaves.
      */

--- a/packages/poseidon-cipher/src/poseidonCipher.ts
+++ b/packages/poseidon-cipher/src/poseidonCipher.ts
@@ -136,7 +136,7 @@ export const poseidonDecrypt = (
 
 /**
  * Decrypt some ciphertext using poseidon encryption
- * @dev Do not throw if the plaintext is invalid
+ * @remarks Does not throw if the plaintext is invalid.
  * @param ciphertext the ciphertext to decrypt
  * @param key the key to decrypt with
  * @param nonce the nonce used to encrypt

--- a/packages/poseidon-cipher/src/utils.ts
+++ b/packages/poseidon-cipher/src/utils.ts
@@ -55,7 +55,7 @@ export const pow5 = (a: bigint): bigint => Fr.mul(a, Fr.square(Fr.square(a)))
 
 /**
  * Given a bigint a, returns a normalized value of a.
- * @dev r is 'r' is the alt_bn128 prime order, so we can use it to normalize values
+ * @remarks r is the alt_bn128 prime order, so we can use it to normalize values.
  * @param a the value to normalize
  * @returns the normalized value of a
  */

--- a/typedoc.js
+++ b/typedoc.js
@@ -12,5 +12,6 @@ const entryPoints = fs
 module.exports = {
     entryPoints,
     name: "zk-kit",
-    entryPointStrategy: "packages"
+    entryPointStrategy: "packages",
+    excludeExternals: true
 }


### PR DESCRIPTION
## Description

This PR fixes all actionable TypeDoc warnings from `yarn docs`. The remaining ones come from external issues (broken third-party `.d.ts` files and TypeDoc’s support matrix) and can’t be fixed without either a breaking API change or upgrading TypeDoc in a way that would introduce more warnings than it removes

## Related Issue(s)

Closes #336 

### What's fixed

  | Warning | Fix |
  |---------|-----|
  | Failed to resolve link to `IMT` | Replaced cross-package `{@link IMT}` with plain text |
  | Failed to resolve link to `IMT#_nodes` | Replaced with `_nodes`,  private properties can't be linked |
  | Failed to resolve link to `LeanIMT#_nodes` | Replaced with `_nodes` , same |
  | Unknown block tag `@dev` | Replaced with `@remarks` (standard TSDoc) |
  | `EdDSAPoseidon` referenced but not included in docs | Added `intentionallyNotExported` to package-level TypeDoc config |

## Checklist

-   [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/CODE_OF_CONDUCT.md).
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes