### PR TITLE
fix(smt): reject forged membership proofs on an empty tree

### DIFF
--- a/packages/smt/src/smt.ts
+++ b/packages/smt/src/smt.ts
@@ -235,6 +235,19 @@ export default class SMT {
      * @returns True if the proof is valid, false otherwise.
      */
     verifyProof(merkleProof: MerkleProof): boolean {
+        // If the tree is empty the only valid proof is a non-membership proof
+        // for the zero root with no siblings. This prevents a self-consistent
+        // proof built around a fabricated root from being accepted as a valid
+        // membership proof against an empty tree.
+        if (this.root === this.zeroNode) {
+            return (
+                merkleProof.root === this.zeroNode &&
+                merkleProof.siblings.length === 0 &&
+                merkleProof.matchingEntry === undefined &&
+                merkleProof.membership === false
+            )
+        }
+
         // If there is not a matching entry it simply obtains the root
         // hash by using the siblings and the path of the key.
         if (!merkleProof.matchingEntry) {

--- a/packages/smt/tests/index.test.ts
+++ b/packages/smt/tests/index.test.ts
@@ -225,6 +225,40 @@ describe("SMT", () => {
 
             expect(tree.verifyProof(proof)).toBeFalsy()
         })
+
+        it.each([["sha256"], ["poseidon2"], ["pedersen"]])(
+            "Should not verify a forged membership proof against an empty tree - %s",
+            (hash) => {
+                const hashFunction = hashes[hash as keyof typeof hashes]
+                const tree = new SMT(hashFunction)
+
+                // The tree is empty, so its root is the zero node and no key is a
+                // member. A self-consistent proof whose own root matches a fabricated
+                // leaf must not be accepted as a membership proof for this tree.
+                const entry: ChildNodes = ["1", "2", "1"]
+                const forgedProof = {
+                    entry,
+                    matchingEntry: undefined,
+                    siblings: [],
+                    root: hashFunction(entry),
+                    membership: true
+                }
+
+                expect(tree.verifyProof(forgedProof)).toBeFalsy()
+            }
+        )
+
+        it.each([["sha256"], ["poseidon2"], ["pedersen"]])(
+            "Should verify a non-membership proof against an empty tree - %s",
+            (hash) => {
+                const tree = new SMT(hashes[hash as keyof typeof hashes])
+
+                const proof = tree.createProof("1")
+
+                expect(proof.membership).toBeFalsy()
+                expect(tree.verifyProof(proof)).toBeTruthy()
+            }
+        )
     })
 
     describe("Create big number trees", () => {


### PR DESCRIPTION
## Description

Closes #343.

`SMT.verifyProof` recomputes the root from the proof's own siblings and compares it **only** against the root stored inside the proof (`merkleProof.root`), never against the tree's state. On an empty tree this lets a self-consistent, fabricated proof pass as a **membership** proof:

```ts
const tree = new SMT(hash) // empty, root === zeroNode
const entry = ["1", "2", "1"]
tree.verifyProof({
  entry,
  matchingEntry: undefined,
  siblings: [],
  root: hash(entry), // fabricated
  membership: true
}) // => true  ❌  (no key is actually a member of an empty tree)
```

It hits the no-matching-entry branch where `calculateRoot(hash(entry), path, [])` trivially equals the fabricated `merkleProof.root`, so the check passes.

## Fix

Add an early guard in `verifyProof`: when the tree is empty (`this.root === this.zeroNode`), the only valid proof is a **non-membership** proof for the zero root with no siblings and no matching entry.

```ts
if (this.root === this.zeroNode) {
    return (
        merkleProof.root === this.zeroNode &&
        merkleProof.siblings.length === 0 &&
        merkleProof.matchingEntry === undefined &&
        merkleProof.membership === false
    )
}
```

## On the discussion in the issue

- @cedoor — _"A proof of non-membership in an empty tree should still be `true`."_ ✅ It is. A genuine non-membership proof from `createProof` on an empty tree is `{ root: zeroNode, siblings: [], matchingEntry: undefined, membership: false }`, which satisfies the guard and still verifies. The added `Should verify a non-membership proof against an empty tree` test covers this.
- @cedoor — _"Not sure about `matchingEntry === undefined`, should a `matchingEntry` still be defined?"_ On an empty tree it cannot be defined: `retrieveEntry`'s descent loop runs only while `node !== this.zeroNode`, so on an empty tree it returns immediately with `{ entry: [key], siblings: [] }` and no `matchingEntry`. A defined `matchingEntry` against an empty tree therefore only ever comes from a forged proof, so rejecting it is correct.

## Tests

Two `it.each` cases over `sha256` / `poseidon2` / `pedersen`:
- `Should not verify a forged membership proof against an empty tree` — fails before the fix, passes after.
- `Should verify a non-membership proof against an empty tree` — guards against false rejection.

`yarn test:library smt` → 63 passing, 100% coverage (statements / branches / functions / lines). `eslint` and `prettier` clean.

## Scope

This PR addresses the empty-tree case reported in #343. The more general observation that `verifyProof` validates only internal proof consistency (a fabricated `proof.root` can also be self-consistent on a **non-empty** tree) is a separate, broader change and is intentionally out of scope here; happy to open a follow-up issue if useful.