### PR TITLE
fix(lean-imt): fixed zero values bug for updateMany and insertMany

### DIFF
--- a/packages/lean-imt/src/lean-imt.ts
+++ b/packages/lean-imt/src/lean-imt.ts
@@ -188,7 +188,7 @@ export default class LeanIMT<N = bigint> {
                 const rightNode = this._nodes[level][index * 2 + 1]
                 const leftNode = this._nodes[level][index * 2]
 
-                const parentNode = rightNode ? this._hash(leftNode, rightNode) : leftNode
+                const parentNode = rightNode !== undefined ? this._hash(leftNode, rightNode) : leftNode
 
                 this._nodes[level + 1][index] = parentNode
             }
@@ -282,7 +282,7 @@ export default class LeanIMT<N = bigint> {
             for (const index of modifiedIndices) {
                 const leftChild = this._nodes[level - 1][2 * index]
                 const rightChild = this._nodes[level - 1][2 * index + 1]
-                this._nodes[level][index] = rightChild ? this._hash(leftChild, rightChild) : leftChild
+                this._nodes[level][index] = rightChild !== undefined ? this._hash(leftChild, rightChild) : leftChild
                 newModifiedIndices.push(index >> 1)
             }
             modifiedIndices = new Set<number>(newModifiedIndices)

--- a/packages/lean-imt/tests/lean-imt.test.ts
+++ b/packages/lean-imt/tests/lean-imt.test.ts
@@ -180,6 +180,17 @@ describe("Lean IMT", () => {
 
             expect(tree.root).toBe(roots[0])
         })
+
+        it(`Should not treat zero leafs as absent`, () => {
+            const tree = new LeanIMT(poseidon)
+
+            // The zero leaf lands at index 1 (a right node), so the parent must
+            // be hash(1, 0). A truthiness check would wrongly skip the zero and
+            // set the root to the left child (1).
+            tree.insertMany([BigInt(1), BigInt(0)])
+
+            expect(tree.root).toBe(poseidon(BigInt(1), BigInt(0)))
+        })
     })
 
     describe("# update", () => {
@@ -331,6 +342,17 @@ describe("Lean IMT", () => {
             const updatedRoot = poseidon(h2_0, updateLeaves[2])
 
             expect(tree.root).toBe(updatedRoot)
+        })
+
+        it(`Should not treat zero leafs updates as absent`, () => {
+            const tree = new LeanIMT(poseidon, [BigInt(1), BigInt(2)])
+
+            // Updating the right node (index 1) to zero must recompute the
+            // parent as hash(1, 0). A truthiness check would wrongly skip the
+            // zero child and set the root to the left child (1).
+            tree.updateMany([1], [BigInt(0)])
+
+            expect(tree.root).toBe(poseidon(BigInt(1), BigInt(0)))
         })
     })
 


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description
InsertMany and updateMany do `node ?`  instead of  `node !== undefined ?`. This causes 0 values not to written to this._nodes, which silently causes invalid roots. 

The fix was doing `node !== undefined` instead of just `node ?` for both updateMany and insertMany.  
I also added two small test that expose this bug (which is now fixed).

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

Fixes #419 

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
<!-- Feel free to remove this section if you will not use it. -->

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [ x] I have read and understand the [contributor guidelines](https://github.com/zk-kit/zk-kit/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/zk-kit/zk-kit/blob/main/CODE_OF_CONDUCT.md).
-   [ x] I have performed a self-review of my code
-   [ x] I have commented my code, particularly in hard-to-understand areas
-   [ x] My changes generate no new warnings
-   [ x] I have run `yarn style` without getting any errors
-   [ x] I have added tests that prove my fix is effective or that my feature works
-   [ x] New and existing unit tests pass locally with my changes