### PR TITLE
fix(lean-imt-plus): fix(lean-imt-plus): validate equal updates before returning

### DIFF
--- a/packages/lean-imt-plus/src/lean-imt-plus.ts
+++ b/packages/lean-imt-plus/src/lean-imt-plus.ts
@@ -161,10 +161,10 @@ export default class LeanIMTPlus<N = bigint> {
      * a separate `insert`.
      */
     public update(oldValue: N, newValue: N) {
-        if (this._eq(oldValue, newValue)) return
         if (this._eq(newValue, this._zero)) throw new Error("Cannot update to the zero value")
         if (this._eq(oldValue, this._zero)) throw new Error("Cannot update the zero value")
         if (!this.has(oldValue)) throw new Error("Value to update does not exist in the tree")
+        if (this._eq(oldValue, newValue)) return
         if (this.has(newValue)) throw new Error("Target value already exists in the tree")
 
         const modified = new Set<number>()

--- a/packages/lean-imt-plus/tests/lean-imt-plus.test.ts
+++ b/packages/lean-imt-plus/tests/lean-imt-plus.test.ts
@@ -240,6 +240,12 @@ describe("LeanIMTPlus", () => {
             expect(t.root).toBe(rootBefore)
         })
 
+        it("validates equal values before treating the update as a no-op", () => {
+            const t = newTree()
+            expect(() => t.update(0n, 0n)).toThrow(/zero/i)
+            expect(() => t.update(99n, 99n)).toThrow(/does not exist/i)
+        })
+
         it("throws on missing old value, present new value, or zero new value", () => {
             const t = newTree()
             t.insertMany([10n, 20n])


### PR DESCRIPTION



BREAKING CHANGE: n

re n

<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->



`LeanIMTPlus.update` returned immediately when `oldValue` and `newValue` were equal. This allowed invalid calls such as `update(0n, 0n)` and updates for nonexistent values to bypass the documented validation checks.

This change moves the equality no-op check after zero-value and source-existence validation. Updating an existing value to itself remains a no-op, while invalid equal-value updates now throw the expected errors.

A regression test has been added for both the reserved zero value and a nonexistent source value.




## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
<!-- Feel free to remove this section if you will not use it. -->

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] I have read and understand the [contributor guidelines](https://github.com/zk-kit/zk-kit/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/zk-kit/zk-kit/blob/main/CODE_OF_CONDUCT.md).
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

> [!IMPORTANT]
> We do not accept pull requests for minor grammatical fixes (e.g., correcting typos, rewording sentences) or for fixing broken links, unless they significantly improve clarity or functionality. These contributions, while appreciated, are not a priority for merging. If you notice any of these issues, please create a [GitHub Issue](https://github.com/zk-kit/zk-kit/issues/new?template=BLANK_ISSUE) to report them so they can be properly tracked and addressed.
